### PR TITLE
refactor: better naming conventions for "locking" mechanism

### DIFF
--- a/contracts/src/registry/ETHRegistry.sol
+++ b/contracts/src/registry/ETHRegistry.sol
@@ -8,16 +8,16 @@ import {IERC1155Singleton} from "./IERC1155Singleton.sol";
 import {IRegistry} from "./IRegistry.sol";
 import {IRegistryDatastore} from "./IRegistryDatastore.sol";
 import {BaseRegistry} from "./BaseRegistry.sol";
-import {UpdatableRegistry} from "./UpdatableRegistry.sol";
+import {PermissionedRegistry} from "./PermissionedRegistry.sol";
 
-contract ETHRegistry is UpdatableRegistry, AccessControl {
+contract ETHRegistry is PermissionedRegistry, AccessControl {
     bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
 
     error NameAlreadyRegistered(string label);
     error NameExpired(uint256 tokenId);
     error CannotReduceExpiration(uint64 oldExpiration, uint64 newExpiration);
 
-    constructor(IRegistryDatastore _datastore) UpdatableRegistry(_datastore) {
+    constructor(IRegistryDatastore _datastore) PermissionedRegistry(_datastore) {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 

--- a/contracts/src/registry/ETHRegistry.sol
+++ b/contracts/src/registry/ETHRegistry.sol
@@ -8,16 +8,16 @@ import {IERC1155Singleton} from "./IERC1155Singleton.sol";
 import {IRegistry} from "./IRegistry.sol";
 import {IRegistryDatastore} from "./IRegistryDatastore.sol";
 import {BaseRegistry} from "./BaseRegistry.sol";
-import {LockableRegistry} from "./LockableRegistry.sol";
+import {UpdatableRegistry} from "./UpdatableRegistry.sol";
 
-contract ETHRegistry is LockableRegistry, AccessControl {
+contract ETHRegistry is UpdatableRegistry, AccessControl {
     bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
 
     error NameAlreadyRegistered(string label);
     error NameExpired(uint256 tokenId);
     error CannotReduceExpiration(uint64 oldExpiration, uint64 newExpiration);
 
-    constructor(IRegistryDatastore _datastore) LockableRegistry(_datastore) {
+    constructor(IRegistryDatastore _datastore) UpdatableRegistry(_datastore) {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
@@ -94,12 +94,12 @@ contract ETHRegistry is LockableRegistry, AccessControl {
         return (_extractExpiry(_flags), uint32(_flags));
     }
 
-    function lock(uint256 tokenId, uint96 flags)
+    function setFlags(uint256 tokenId, uint96 flags)
         external
         onlyTokenOwner(tokenId)
         returns (uint256 newTokenId)
     {
-        uint96 newFlags = _lock(tokenId, flags);
+        uint96 newFlags = _setFlags(tokenId, flags);
         newTokenId = (tokenId & ~uint256(FLAGS_MASK)) | (newFlags & FLAGS_MASK);
         if (tokenId != newTokenId) {
             address owner = ownerOf(tokenId);

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -9,7 +9,7 @@ import {IRegistry} from "./IRegistry.sol";
 import {IRegistryDatastore} from "./IRegistryDatastore.sol";
 import {BaseRegistry} from "./BaseRegistry.sol";
 
-abstract contract UpdatableRegistry is BaseRegistry {
+abstract contract PermissionedRegistry is BaseRegistry {
     uint96 public constant FLAGS_MASK = 0x7;
     uint96 public constant FLAG_SUBREGISTRY_LOCKED = 0x1;
     uint96 public constant FLAG_RESOLVER_LOCKED = 0x2;

--- a/contracts/src/registry/RootRegistry.sol
+++ b/contracts/src/registry/RootRegistry.sol
@@ -7,15 +7,15 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IRegistry} from "./IRegistry.sol";
 import {IRegistryDatastore} from "./IRegistryDatastore.sol";
-import {LockableRegistry} from "./LockableRegistry.sol";
+import {UpdatableRegistry} from "./UpdatableRegistry.sol";
 import {BaseRegistry} from "./BaseRegistry.sol";
 
-contract RootRegistry is LockableRegistry, AccessControl {
+contract RootRegistry is UpdatableRegistry, AccessControl {
     bytes32 public constant TLD_ISSUER_ROLE = keccak256("TLD_ISSUER_ROLE");
 
     mapping(uint256 tokenId=>string) uris;
 
-    constructor(IRegistryDatastore _datastore) LockableRegistry(_datastore) {
+    constructor(IRegistryDatastore _datastore) UpdatableRegistry(_datastore) {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
@@ -59,12 +59,12 @@ contract RootRegistry is LockableRegistry, AccessControl {
         datastore.setSubregistry(tokenId, address(0), 0);
     }
 
-    function lock(uint256 tokenId, uint96 flags)
+    function setFlags(uint256 tokenId, uint96 flags)
         external
         onlyTokenOwner(tokenId)
         returns(uint96)
     {
-        return _lock(tokenId, flags);
+        return _setFlags(tokenId, flags);
     }
 
     function setUri(uint256 tokenId, string memory _uri) 

--- a/contracts/src/registry/RootRegistry.sol
+++ b/contracts/src/registry/RootRegistry.sol
@@ -7,15 +7,15 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IRegistry} from "./IRegistry.sol";
 import {IRegistryDatastore} from "./IRegistryDatastore.sol";
-import {UpdatableRegistry} from "./UpdatableRegistry.sol";
+import {PermissionedRegistry} from "./PermissionedRegistry.sol";
 import {BaseRegistry} from "./BaseRegistry.sol";
 
-contract RootRegistry is UpdatableRegistry, AccessControl {
+contract RootRegistry is PermissionedRegistry, AccessControl {
     bytes32 public constant TLD_ISSUER_ROLE = keccak256("TLD_ISSUER_ROLE");
 
     mapping(uint256 tokenId=>string) uris;
 
-    constructor(IRegistryDatastore _datastore) UpdatableRegistry(_datastore) {
+    constructor(IRegistryDatastore _datastore) PermissionedRegistry(_datastore) {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 

--- a/contracts/src/registry/UpdatableRegistry.sol
+++ b/contracts/src/registry/UpdatableRegistry.sol
@@ -9,7 +9,7 @@ import {IRegistry} from "./IRegistry.sol";
 import {IRegistryDatastore} from "./IRegistryDatastore.sol";
 import {BaseRegistry} from "./BaseRegistry.sol";
 
-abstract contract LockableRegistry is BaseRegistry {
+abstract contract UpdatableRegistry is BaseRegistry {
     uint96 public constant FLAGS_MASK = 0x7;
     uint96 public constant FLAG_SUBREGISTRY_LOCKED = 0x1;
     uint96 public constant FLAG_RESOLVER_LOCKED = 0x2;
@@ -18,7 +18,7 @@ abstract contract LockableRegistry is BaseRegistry {
     constructor(IRegistryDatastore _datastore) BaseRegistry(_datastore) {
     }
 
-    function _lock(uint256 tokenId, uint96 _flags)
+    function _setFlags(uint256 tokenId, uint96 _flags)
         internal
         withSubregistryFlags(tokenId, FLAG_FLAGS_LOCKED, 0)
         returns(uint96 newFlags)

--- a/contracts/test/ETHRegistry.t.sol
+++ b/contracts/test/ETHRegistry.t.sol
@@ -31,7 +31,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         vm.assertEq(tokenId, expectedId);
     }
 
-    function test_register_locked() public {
+    function test_register_setFlagsed() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
         uint256 expectedId =
             uint256(keccak256("test2") & 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8) | flags;
@@ -42,7 +42,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         vm.assertEq(tokenId, expectedId);
     }
 
-    function test_lock_name() public {
+    function test_setFlags_name() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
         uint256 oldTokenId = registry.register("test2", address(this), registry, 0, uint64(block.timestamp) + 86400);
 
@@ -52,7 +52,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         vm.expectEmit(true, true, true, true);
         emit TransferSingle(address(this), address(0), address(this), expectedTokenId, 1);
 
-        uint256 newTokenId = registry.lock(oldTokenId, flags);
+        uint256 newTokenId = registry.setFlags(oldTokenId, flags);
         vm.assertEq(newTokenId, expectedTokenId);
     }
 
@@ -60,7 +60,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
 
         uint256 oldTokenId = registry.register("test2", address(this), registry, flags, uint64(block.timestamp) + 86400);
-        uint256 newTokenId = registry.lock(oldTokenId, 0);
+        uint256 newTokenId = registry.setFlags(oldTokenId, 0);
         vm.assertEq(oldTokenId, newTokenId);
     }
 
@@ -79,7 +79,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         vm.assertEq(address(registry.getSubregistry("test2")), address(this));
     }
 
-    function test_Revert_cannot_set_locked_subregistry() public {
+    function test_Revert_cannot_set_setFlagsed_subregistry() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED();
         uint256 tokenId = registry.register("test2", address(this), registry, flags, uint64(block.timestamp) + 86400);
 
@@ -93,7 +93,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         vm.assertEq(address(registry.getResolver("test2")), address(this));
     }
 
-    function test_Revert_cannot_set_locked_resolver() public {
+    function test_Revert_cannot_set_setFlagsed_resolver() public {
         uint96 flags = registry.FLAG_RESOLVER_LOCKED();
         uint256 tokenId = registry.register("test2", address(this), registry, flags, uint64(block.timestamp) + 86400);
 
@@ -101,12 +101,12 @@ contract TestETHRegistry is Test, ERC1155Holder {
         registry.setResolver(tokenId, address(this));
     }
 
-    function test_Revert_cannot_set_locked_flags() public {
+    function test_Revert_cannot_set_setFlagsed_flags() public {
         uint96 flags = registry.FLAG_FLAGS_LOCKED();
         uint256 tokenId = registry.register("test2", address(this), registry, flags, uint64(block.timestamp) + 86400);
 
         vm.expectRevert(abi.encodeWithSelector(BaseRegistry.InvalidSubregistryFlags.selector, tokenId, registry.FLAG_FLAGS_LOCKED(), 0));
-        registry.lock(tokenId, flags);
+        registry.setFlags(tokenId, flags);
     }
 
     function test_relinquish() public {

--- a/contracts/test/ETHRegistry.t.sol
+++ b/contracts/test/ETHRegistry.t.sol
@@ -24,33 +24,25 @@ contract TestETHRegistry is Test, ERC1155Holder {
     function test_register_unlocked() public {
         uint256 expectedId =
             uint256(keccak256("test2") & 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8);
-        vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(this), address(0), address(this), expectedId, 1);
 
         uint256 tokenId = registry.register("test2", address(this), registry, 0, uint64(block.timestamp) + 86400);
         vm.assertEq(tokenId, expectedId);
     }
 
-    function test_register_setFlagsed() public {
+    function test_register_locked() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
         uint256 expectedId =
             uint256(keccak256("test2") & 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8) | flags;
-        vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(this), address(0), address(this), expectedId, 1);
 
         uint256 tokenId = registry.register("test2", address(this), registry, flags, uint64(block.timestamp) + 86400);
         vm.assertEq(tokenId, expectedId);
     }
 
-    function test_setFlags_name() public {
+    function test_lock_name() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
         uint256 oldTokenId = registry.register("test2", address(this), registry, 0, uint64(block.timestamp) + 86400);
 
-        vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(this), address(this), address(0), oldTokenId, 1);
         uint256 expectedTokenId = oldTokenId | flags;
-        vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(this), address(0), address(this), expectedTokenId, 1);
 
         uint256 newTokenId = registry.setFlags(oldTokenId, flags);
         vm.assertEq(newTokenId, expectedTokenId);
@@ -79,7 +71,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         vm.assertEq(address(registry.getSubregistry("test2")), address(this));
     }
 
-    function test_Revert_cannot_set_setFlagsed_subregistry() public {
+    function test_Revert_cannot_set_locked_subregistry() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED();
         uint256 tokenId = registry.register("test2", address(this), registry, flags, uint64(block.timestamp) + 86400);
 
@@ -93,7 +85,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         vm.assertEq(address(registry.getResolver("test2")), address(this));
     }
 
-    function test_Revert_cannot_set_setFlagsed_resolver() public {
+    function test_Revert_cannot_set_locked_resolver() public {
         uint96 flags = registry.FLAG_RESOLVER_LOCKED();
         uint256 tokenId = registry.register("test2", address(this), registry, flags, uint64(block.timestamp) + 86400);
 
@@ -101,7 +93,7 @@ contract TestETHRegistry is Test, ERC1155Holder {
         registry.setResolver(tokenId, address(this));
     }
 
-    function test_Revert_cannot_set_setFlagsed_flags() public {
+    function test_Revert_cannot_set_locked_flags() public {
         uint96 flags = registry.FLAG_FLAGS_LOCKED();
         uint256 tokenId = registry.register("test2", address(this), registry, flags, uint64(block.timestamp) + 86400);
 

--- a/contracts/test/RootRegistry.t.sol
+++ b/contracts/test/RootRegistry.t.sol
@@ -32,7 +32,7 @@ contract TestRootRegistry is Test, ERC1155Holder {
         vm.assertEq(flags, 0);
     }
 
-    function test_register_locked() public {
+    function test_register_setFlagsed() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
         uint256 expectedId = uint256(keccak256("test2"));
         vm.expectEmit(true, true, true, true);
@@ -44,10 +44,10 @@ contract TestRootRegistry is Test, ERC1155Holder {
         vm.assertEq(flags, actualFlags);
     }
 
-    function test_lock_name() public {
+    function test_setFlags_name() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
         uint256 tokenId = registry.mint("test2", address(this), registry, 0, "");
-        uint96 actualFlags = registry.lock(tokenId, flags);
+        uint96 actualFlags = registry.setFlags(tokenId, flags);
         vm.assertEq(flags, actualFlags);
         uint96 actualFlags2 = registry.flags(tokenId);
         vm.assertEq(flags, actualFlags2);
@@ -57,7 +57,7 @@ contract TestRootRegistry is Test, ERC1155Holder {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
 
         uint256 tokenId = registry.mint("test2", address(this), registry, flags, "");
-        uint96 newFlags = registry.lock(tokenId, 0);
+        uint96 newFlags = registry.setFlags(tokenId, 0);
         vm.assertEq(flags, newFlags);
         uint96 newFlags2 = registry.flags(tokenId);
         vm.assertEq(flags, newFlags2);
@@ -69,7 +69,7 @@ contract TestRootRegistry is Test, ERC1155Holder {
         vm.assertEq(address(registry.getSubregistry("test")), address(this));
     }
 
-    function test_Revert_cannot_set_locked_subregistry() public {
+    function test_Revert_cannot_set_setFlagsed_subregistry() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED();
         uint256 tokenId = registry.mint("test", address(this), registry, flags, "");
 
@@ -83,7 +83,7 @@ contract TestRootRegistry is Test, ERC1155Holder {
         vm.assertEq(address(registry.getResolver("test")), address(this));
     }
 
-    function test_Revert_cannot_set_locked_resolver() public {
+    function test_Revert_cannot_set_setFlagsed_resolver() public {
         uint96 flags = registry.FLAG_RESOLVER_LOCKED();
         uint256 tokenId = registry.mint("test", address(this), registry, flags, "");
 
@@ -91,12 +91,12 @@ contract TestRootRegistry is Test, ERC1155Holder {
         registry.setResolver(tokenId, address(this));
     }
 
-    function test_Revert_cannot_set_locked_flags() public {
+    function test_Revert_cannot_set_setFlagsed_flags() public {
         uint96 flags = registry.FLAG_FLAGS_LOCKED();
         uint256 tokenId = registry.mint("test", address(this), registry, flags, "");
 
         vm.expectRevert(abi.encodeWithSelector(BaseRegistry.InvalidSubregistryFlags.selector, tokenId, registry.FLAG_FLAGS_LOCKED(), 0));
-        registry.lock(tokenId, flags);
+        registry.setFlags(tokenId, flags);
     }
 
     function test_set_uri() public {

--- a/contracts/test/RootRegistry.t.sol
+++ b/contracts/test/RootRegistry.t.sol
@@ -23,8 +23,6 @@ contract TestRootRegistry is Test, ERC1155Holder {
 
     function test_register_unlocked() public {
         uint256 expectedId = uint256(keccak256("test2"));
-        vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(this), address(0), address(this), expectedId, 1);
 
         uint256 tokenId = registry.mint("test2", address(this), registry, 0, "");
         vm.assertEq(tokenId, expectedId);
@@ -32,11 +30,9 @@ contract TestRootRegistry is Test, ERC1155Holder {
         vm.assertEq(flags, 0);
     }
 
-    function test_register_setFlagsed() public {
+    function test_register_locked() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
         uint256 expectedId = uint256(keccak256("test2"));
-        vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(this), address(0), address(this), expectedId, 1);
 
         uint256 tokenId = registry.mint("test2", address(this), registry, flags, "");
         vm.assertEq(tokenId, expectedId);
@@ -44,7 +40,7 @@ contract TestRootRegistry is Test, ERC1155Holder {
         vm.assertEq(flags, actualFlags);
     }
 
-    function test_setFlags_name() public {
+    function test_lock_name() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED() | registry.FLAG_RESOLVER_LOCKED();
         uint256 tokenId = registry.mint("test2", address(this), registry, 0, "");
         uint96 actualFlags = registry.setFlags(tokenId, flags);
@@ -69,7 +65,7 @@ contract TestRootRegistry is Test, ERC1155Holder {
         vm.assertEq(address(registry.getSubregistry("test")), address(this));
     }
 
-    function test_Revert_cannot_set_setFlagsed_subregistry() public {
+    function test_Revert_cannot_set_locked_subregistry() public {
         uint96 flags = registry.FLAG_SUBREGISTRY_LOCKED();
         uint256 tokenId = registry.mint("test", address(this), registry, flags, "");
 
@@ -83,7 +79,7 @@ contract TestRootRegistry is Test, ERC1155Holder {
         vm.assertEq(address(registry.getResolver("test")), address(this));
     }
 
-    function test_Revert_cannot_set_setFlagsed_resolver() public {
+    function test_Revert_cannot_set_locked_resolver() public {
         uint96 flags = registry.FLAG_RESOLVER_LOCKED();
         uint256 tokenId = registry.mint("test", address(this), registry, flags, "");
 
@@ -91,7 +87,7 @@ contract TestRootRegistry is Test, ERC1155Holder {
         registry.setResolver(tokenId, address(this));
     }
 
-    function test_Revert_cannot_set_setFlagsed_flags() public {
+    function test_Revert_cannot_set_locked_flags() public {
         uint96 flags = registry.FLAG_FLAGS_LOCKED();
         uint256 tokenId = registry.mint("test", address(this), registry, flags, "");
 


### PR DESCRIPTION
* `LockableRegistry` - `UpdatableRegistry`
* `lock()` -> `setFlags()`