### PR TITLE
Add `DNSAliasResolver`

### DIFF
--- a/contracts/src/L1/dns/DNSAliasResolver.sol
+++ b/contracts/src/L1/dns/DNSAliasResolver.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+import {CCIPReader} from "@ens/contracts/ccipRead/CCIPReader.sol";
+import {BytesUtils} from "@ens/contracts/utils/BytesUtils.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {ResolverProfileRewriter} from "../../common/ResolverProfileRewriter.sol";
+import {IUniversalResolver} from "@ens/contracts/universalResolver/IUniversalResolver.sol";
+import {IFeatureSupporter} from "@ens/contracts/utils/IFeatureSupporter.sol";
+import {ResolverFeatures} from "@ens/contracts/resolvers/ResolverFeatures.sol";
+import {IExtendedDNSResolver} from "@ens/contracts/resolvers/profiles/IExtendedDNSResolver.sol";
+
+/// @title DNSAliasResolver
+/// @notice Gasless DNSSEC resolver that directs to another name.
+/// Rewrite: "*.nick.com" + `ENS1 <this> com eth` &rarr; "*.nick.eth"
+/// Replace: "nick.com" + `ENS1 <this> nick.eth` &rarr; "nick.eth"
+contract DNSAliasResolver is
+    ERC165,
+    CCIPReader,
+    IFeatureSupporter,
+    IExtendedDNSResolver
+{
+    IUniversalResolver public immutable universalResolver;
+
+    constructor(IUniversalResolver _universalResolver) CCIPReader(0) {
+        universalResolver = _universalResolver;
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165) returns (bool) {
+        return
+            type(IExtendedDNSResolver).interfaceId == interfaceId ||
+            type(IFeatureSupporter).interfaceId == interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IFeatureSupporter
+    function supportsFeature(bytes4 feature) external pure returns (bool) {
+        return ResolverFeatures.RESOLVE_MULTICALL == feature;
+    }
+
+    /// @dev Resolve the records using the name stored in the context.
+    function resolve(
+        bytes calldata name,
+        bytes calldata data,
+        bytes calldata context
+    ) external view returns (bytes memory) {
+        bytes memory newName = _parseContext(name, context);
+        ccipRead(
+            address(universalResolver),
+            abi.encodeCall(
+                IUniversalResolver.resolve,
+                (
+                    newName,
+                    ResolverProfileRewriter.replaceNode(
+                        data,
+                        NameCoder.namehash(newName, 0)
+                    )
+                )
+            )
+        );
+    }
+
+    /// @dev Rewrite or replace name using context.
+    ///      If context is `<old-suffix> <new-suffix>`, rewrite name with new suffix.
+    ///      Otherwise, replace name with context.
+    function _parseContext(
+        bytes calldata name,
+        bytes calldata context
+    ) internal pure returns (bytes memory newName) {
+        uint256 sep = BytesUtils.find(context, 0, context.length, " ");
+        if (sep < context.length) {
+            bytes memory oldSuffix = NameCoder.encode(string(context[:sep]));
+            bytes memory newSuffix = NameCoder.encode(
+                string(context[sep + 1:])
+            );
+            (bool matched, , uint256 suffixOffset) = matchSuffix(
+                name,
+                0,
+                NameCoder.namehash(oldSuffix, 0)
+            );
+            require(matched, "expected suffix match");
+            return abi.encodePacked(name[:suffixOffset], newSuffix);
+        } else {
+            return NameCoder.encode(string(context));
+        }
+    }
+
+    // ********************************************************************************
+    // https://github.com/ensdomains/ens-contracts/blob/fix/namecoder-iter/contracts/utils/NameCoder.sol#L270
+    // https://github.com/ensdomains/ens-contracts/pull/459
+    // ********************************************************************************
+    function matchSuffix(
+        bytes memory name,
+        uint256 offset,
+        bytes32 nodeSuffix
+    ) internal pure returns (bool matched, bytes32 node, uint256 suffixOffset) {
+        (bytes32 labelHash, uint256 next) = NameCoder.readLabel(name, offset);
+        if (labelHash != bytes32(0)) {
+            (matched, node, suffixOffset) = matchSuffix(name, next, nodeSuffix);
+            if (node == nodeSuffix) {
+                matched = true;
+                suffixOffset = next;
+            }
+            node = keccak256(abi.encode(node, labelHash));
+        }
+        if (node == nodeSuffix) {
+            matched = true;
+        }
+    }
+}

--- a/contracts/src/common/ResolverProfileRewriter.sol
+++ b/contracts/src/common/ResolverProfileRewriter.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+library ResolverProfileRewriter {
+    /// @dev Replace the node in the calldata with a new node.
+    ///      Supports `multicall()` to arbirary depth.
+    /// @param call The calldata for a resolver.
+    /// @param node The replacement node.
+    /// @return copy A copy of the calldata with node replaced.
+    function replaceNode(
+        bytes calldata call,
+        bytes32 node
+    ) internal pure returns (bytes memory copy) {
+        copy = call; // make a copy
+        assembly {
+            function replace(ptr, _node) {
+                switch shr(224, mload(add(ptr, 32))) // call selector
+                case 0xac9650d8 {
+                    // multicall (bytes[])
+                    let off := add(ptr, 36)
+                    off := add(off, mload(off))
+                    let size := shl(5, mload(off))
+                    // prettier-ignore
+                    for { } size { size := sub(size, 32) } {
+                        replace(add(add(off, 32), mload(add(off, size))), _node)
+                    }
+                }
+                default {
+                    mstore(add(ptr, 36), _node) // replace node
+                }
+            }
+            replace(copy, node)
+        }
+    }
+}

--- a/contracts/test/dns/DNSTLDResolver.test.ts
+++ b/contracts/test/dns/DNSTLDResolver.test.ts
@@ -55,6 +55,9 @@ async function fixture() {
     name: dnsnameResolver,
     resolverAddress: dnsTXTResolver.address,
   });
+  const dnsAliasResolver = await chain.viem.deployContract("DNSAliasResolver", [
+    mainnetV2.universalResolver.address,
+  ]);
   return {
     mainnetV1,
     mainnetV2,
@@ -62,6 +65,7 @@ async function fixture() {
     mockDNSSEC,
     dnsTLDResolver,
     dnsTXTResolver,
+    dnsAliasResolver,
     async expectGasless(kp: KnownProfile) {
       const bundle = bundleCalls(makeResolutions(kp));
       const [answer, resolver] = await mainnetV2.universalResolver.read.resolve(
@@ -434,5 +438,83 @@ describe("DNSTLDResolver", () => {
         texts: [{ key: TEXT_DNSSEC_CONTEXT, value: context }],
       });
     });
+  });
+
+  describe("DNSAliasResolver", () => {
+    shouldSupportInterfaces({
+      contract: () =>
+        chain.networkHelpers
+          .loadFixture(fixture)
+          .then((F) => F.dnsAliasResolver),
+      interfaces: ["IERC165", "IExtendedDNSResolver", "IFeatureSupporter"],
+    });
+
+    shouldSupportFeatures({
+      contract: () =>
+        chain.networkHelpers
+          .loadFixture(fixture)
+          .then((F) => F.dnsAliasResolver),
+      features: {
+        RESOLVER: ["RESOLVE_MULTICALL"],
+      },
+    });
+
+    for (const context of ["com eth", "test.com test.eth", "test.eth"]) {
+      function create(
+        configure: (F: Awaited<ReturnType<typeof fixture>>) => Promise<void>,
+      ) {
+        return async () => {
+          const F = await chain.networkHelpers.loadFixture(fixture);
+          const kp: KnownProfile = {
+            name: "test.eth",
+            addresses: [{ coinType: COIN_TYPE_ETH, value: testAddress }],
+            texts: [{ key: "url", value: "https://ens.domains" }],
+          };
+          await F.mainnetV2.setupName({
+            name: kp.name,
+            resolverAddress: F.ssResolver.address,
+          });
+          for (const res of makeResolutions(kp)) {
+            await F.ssResolver.write.setResponse([res.call, res.answer]);
+          }
+          await configure(F);
+          await F.mockDNSSEC.write.setResponse([
+            encodeRRs([
+              makeTXT(
+                basicProfile.name,
+                `ENS1 ${F.dnsAliasResolver.address} ${context}`,
+              ),
+            ]),
+          ]);
+          await F.expectGasless({ ...kp, name: basicProfile.name });
+        };
+      }
+
+      describe(context.replace(" ", " => "), () => {
+        it(
+          "onchain immediate",
+          create(async () => {}),
+        );
+        it(
+          "onchain extended",
+          create(async (F) => {
+            await F.ssResolver.write.setExtended([true]);
+          }),
+        );
+        it(
+          "offchain immediate",
+          create(async (F) => {
+            await F.ssResolver.write.setOffchain([true]);
+          }),
+        );
+        it(
+          "offchain extended",
+          create(async (F) => {
+            await F.ssResolver.write.setExtended([true]);
+            await F.ssResolver.write.setOffchain([true]);
+          }),
+        );
+      });
+    }
   });
 });

--- a/contracts/test/utils/ResolverProfileRewriter.t.sol
+++ b/contracts/test/utils/ResolverProfileRewriter.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {ResolverProfileRewriter} from "../../src/common/ResolverProfileRewriter.sol";
+import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
+import {IAddressResolver} from "@ens/contracts/resolvers/profiles/IAddressResolver.sol";
+
+contract ResolverProfileRewriterTest is Test {
+    function replaceNode(
+        bytes calldata call,
+        bytes32 node
+    ) public pure returns (bytes memory) {
+        return ResolverProfileRewriter.replaceNode(call, node);
+    }
+
+    function drop4(bytes calldata v) public pure returns (bytes memory) {
+        return v[4:];
+    }
+
+    function testFuzz_replaceNode_call(
+        bytes32 node,
+        uint256 coinType
+    ) external view {
+        (bytes32 x, uint256 c) = abi.decode(
+            this.drop4(
+                this.replaceNode(
+                    abi.encodeCall(
+                        IAddressResolver.addr,
+                        (keccak256("a"), coinType)
+                    ),
+                    node
+                )
+            ),
+            (bytes32, uint256)
+        );
+        assertEq(x, node, "node");
+        assertEq(c, coinType, "coinType");
+    }
+
+    function testFuzz_replaceNode_multicall(
+        bytes32 node,
+        uint8 calls
+    ) external view {
+        bytes[] memory m = new bytes[](calls);
+        for (uint256 i; i < calls; i++) {
+            m[i] = abi.encodeCall(IAddressResolver.addr, (keccak256("a"), i));
+        }
+        m = abi.decode(
+            this.drop4(
+                this.replaceNode(
+                    abi.encodeCall(IMulticallable.multicall, (m)),
+                    node
+                )
+            ),
+            (bytes[])
+        );
+        assertEq(m.length, calls, "count");
+        for (uint256 i; i < calls; i++) {
+            (bytes32 x, uint256 c) = abi.decode(
+                this.drop4(m[i]),
+                (bytes32, uint256)
+            );
+            assertEq(x, node, "node");
+            assertEq(c, i, "coinType");
+        }
+    }
+}


### PR DESCRIPTION
- added [DNSAliasResolver.sol](https://github.com/ensdomains/namechain/blob/feat/bet-412-dns-alias-resolver/contracts/src/L1/dns/DNSAliasResolver.sol) and [tests](https://github.com/ensdomains/namechain/blob/feat/bet-412-dns-alias-resolver/contracts/test/dns/DNSTLDResolver.test.ts#L443)
    * supports `resolve(multicall)`
    * ~~temporary `matchSuffix()`~~ &rarr; https://github.com/ensdomains/ens-contracts/pull/459
    * leverages `UniversalResolver.resolve()`
    * `ENS1 <DNSAliasResolver> <name>` → `UR.resolve(name, ...)`
        * eg. `raffy.xyz` + `<R> raffy.base.eth` → `raffy.base.eth`
- added [ResolverProfileRewriter.sol](https://github.com/ensdomains/namechain/blob/feat/bet-412-dns-alias-resolver/contracts/src/common/ResolverProfileRewriter.sol) and [ResolverProfileRewriter.t.sol](https://github.com/ensdomains/namechain/blob/feat/bet-412-dns-alias-resolver/contracts/test/utils/ResolverProfileRewriter.t.sol)
