### PR TITLE
Add Forked DNSSEC Test

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -15,6 +15,7 @@ docs/
 
 node_modules/
 cache_hardhat/
+edr-fork-cache/
 artifacts/
 typechain-types/
 

--- a/contracts/src/L1/dns/DNSTLDResolver.sol
+++ b/contracts/src/L1/dns/DNSTLDResolver.sol
@@ -20,6 +20,7 @@ import {ResolverFeatures} from "@ens/contracts/resolvers/ResolverFeatures.sol";
 // resolver profiles
 import {IExtendedResolver} from "@ens/contracts/resolvers/profiles/IExtendedResolver.sol";
 import {IExtendedDNSResolver} from "@ens/contracts/resolvers/profiles/IExtendedDNSResolver.sol";
+import {IAddrResolver} from "@ens/contracts/resolvers/profiles/IAddrResolver.sol";
 import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
 
 /// @dev DNS class for the "Internet" according to RFC-1035.
@@ -360,11 +361,16 @@ contract DNSTLDResolver is
                 return addr;
             }
         }
-        (, resolver, , ) = RegistryUtils.findResolver(
-            rootRegistry,
-            NameCoder.encode(string(v)),
-            0
-        );
+        bytes memory name = NameCoder.encode(string(v));
+        (, address r, , ) = RegistryUtils.findResolver(rootRegistry, name, 0);
+        if (r != address(0)) {
+            // according to V1, this must be immediate onchain
+            try IAddrResolver(r).addr(NameCoder.namehash(name, 0)) returns (
+                address payable a
+            ) {
+                resolver = a;
+            } catch {}
+        }
     }
 
     /// @dev Decode `v[off:end]` as raw TXT chunks.

--- a/contracts/test/deployV2Fixture.test.ts
+++ b/contracts/test/deployV2Fixture.test.ts
@@ -1,5 +1,5 @@
 import hre from "hardhat";
-import type { Address } from "viem";
+import { zeroAddress, type Address } from "viem";
 import { describe, expect, it } from "vitest";
 
 import { deployV2Fixture, ROLES } from "./fixtures/deployV2Fixture.ts";
@@ -29,18 +29,25 @@ function expectRegistries(
 describe("deployV2Fixture", () => {
   it("setupName()", async () => {
     const F = await loadFixture();
-    const { labels, tokenId, parentRegistry, exactRegistry, registries } =
-      await F.setupName({
-        name: "test.eth",
-      });
+    const {
+      labels,
+      tokenId,
+      parentRegistry,
+      exactRegistry,
+      registries,
+      dedicatedResolver,
+    } = await F.setupName({
+      name: "test.eth",
+    });
     expectVar({ labels }).toStrictEqual(["test", "eth"]);
     expectVar({ tokenId }).toEqual(labelToCanonicalId("test"));
     expectVar({ parentRegistry }).toEqual(registries[1]);
     expectVar({ exactRegistry }).toBeUndefined();
+    expectVar({ dedicatedResolver }).toBeDefined();
     expectRegistries(registries, [undefined, F.ethRegistry, F.rootRegistry]);
   });
 
-  it("setupName() w/ exact", async () => {
+  it("setupName() w/exact", async () => {
     const F = await loadFixture();
     const { labels, tokenId, parentRegistry, exactRegistry, registries } =
       await F.setupName({
@@ -56,6 +63,15 @@ describe("deployV2Fixture", () => {
       F.ethRegistry,
       F.rootRegistry,
     ]);
+  });
+
+  it("setupName() w/resolver", async () => {
+    const F = await loadFixture();
+    const { dedicatedResolver } = await F.setupName({
+      name: "test.eth",
+      resolverAddress: zeroAddress,
+    });
+    expectVar({ dedicatedResolver }).toBeUndefined();
   });
 
   it("overlapping names", async () => {

--- a/contracts/test/dns/DNSTLDResolver.mainnet.test.ts
+++ b/contracts/test/dns/DNSTLDResolver.mainnet.test.ts
@@ -18,6 +18,7 @@ const KNOWN: KnownProfile[] = [
   },
   {
     name: "raffy.xyz",
+    texts: [{ key: "avatar", value: "https://raffy.xyz/ens.jpg" }],
     addresses: [
       {
         coinType: COIN_TYPE_ETH,

--- a/contracts/test/dns/DNSTLDResolver.mainnet.test.ts
+++ b/contracts/test/dns/DNSTLDResolver.mainnet.test.ts
@@ -1,0 +1,95 @@
+import hre from "hardhat";
+import { describe, it } from "vitest";
+import { namehash } from "viem";
+import { dnsEncodeName, getLabelAt } from "../utils/utils.js";
+import { deployV2Fixture } from "../fixtures/deployV2Fixture.js";
+import { expectVar } from "../utils/expectVar.ts";
+import {
+  COIN_TYPE_ETH,
+  KnownProfile,
+  bundleCalls,
+  makeResolutions,
+} from "../utils/resolutions.js";
+
+const KNOWN: KnownProfile[] = [
+  {
+    name: "brantly.cash",
+    texts: [{ key: "com.twitter", value: "brantlymillegan" }],
+  },
+  {
+    name: "raffy.xyz",
+    addresses: [
+      {
+        coinType: COIN_TYPE_ETH,
+        value: "0x51050ec063d393217B436747617aD1C2285Aeeee",
+      },
+    ],
+  },
+];
+
+const url =
+  hre.config.networks.mainnet.type === "http" &&
+  (await hre.config.networks.mainnet.url.get());
+
+let tests = () => {};
+if (url) {
+  const chain = await hre.network.connect({
+    override: { forking: { enabled: true, url } },
+  });
+
+  async function fixture() {
+    await chain.networkHelpers.mine(); // https://github.com/NomicFoundation/hardhat/issues/5511#issuecomment-2288072104
+    const mainnetV2 = await deployV2Fixture(chain, true); // CCIP on UR
+    const ensRegistry = await chain.viem.getContractAt(
+      "ENSRegistry",
+      "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+    );
+    const dnsTLDResolverV1 = await chain.viem.getContractAt(
+      "OffchainDNSResolver",
+      await ensRegistry.read.resolver([namehash("com")]),
+    );
+    const DNSSEC = await chain.viem.getContractAt(
+      "DNSSEC",
+      await dnsTLDResolverV1.read.oracle(),
+    );
+    const dnsTLDResolver = await chain.viem.deployContract("DNSTLDResolver", [
+      ensRegistry.address,
+      dnsTLDResolverV1.address,
+      mainnetV2.rootRegistry.address,
+      DNSSEC.address,
+      [await dnsTLDResolverV1.read.gatewayURL()],
+      ["x-batch-gateway:true"],
+    ]);
+    for (const name of new Set(KNOWN.map((x) => getLabelAt(x.name, -1)))) {
+      await mainnetV2.setupName({
+        name,
+        resolverAddress: dnsTLDResolver.address,
+      });
+    }
+    return {
+      ensRegistry,
+      dnsTLDResolverV1,
+      DNSSEC,
+      mainnetV2,
+      dnsTLDResolver,
+    };
+  }
+
+  tests = () => {
+    for (const kp of KNOWN) {
+      it(kp.name, async () => {
+        const F = await chain.networkHelpers.loadFixture(fixture);
+        const bundle = bundleCalls(makeResolutions(kp));
+        const [answer, resolver] =
+          await F.mainnetV2.universalResolver.read.resolve([
+            dnsEncodeName(kp.name),
+            bundle.call,
+          ]);
+        expectVar({ resolver }).toEqualAddress(F.dnsTLDResolver.address);
+        bundle.expect(answer);
+      });
+    }
+  };
+}
+
+describe.skipIf(!url)("DNSTLDResolver (mainnet)", tests);

--- a/contracts/test/dns/DNSTLDResolver.mainnet.test.ts
+++ b/contracts/test/dns/DNSTLDResolver.mainnet.test.ts
@@ -28,9 +28,9 @@ const KNOWN: KnownProfile[] = [
   },
 ];
 
-const url =
-  hre.config.networks.mainnet.type === "http" &&
-  (await hre.config.networks.mainnet.url.get());
+const url = await (async (config) => {
+  return config.type === "http" && config.url.get();
+})(hre.config.networks.mainnet).catch(() => {});
 
 let tests = () => {};
 if (url) {

--- a/contracts/test/dns/DNSTLDResolver.mainnet.test.ts
+++ b/contracts/test/dns/DNSTLDResolver.mainnet.test.ts
@@ -13,8 +13,13 @@ import {
 
 const KNOWN: KnownProfile[] = [
   {
-    name: "brantly.cash",
-    texts: [{ key: "com.twitter", value: "brantlymillegan" }],
+    name: "taytems.xyz",
+    addresses: [
+      {
+        coinType: COIN_TYPE_ETH,
+        value: "0x8e8Db5CcEF88cca9d624701Db544989C996E3216",
+      },
+    ],
   },
   {
     name: "raffy.xyz",
@@ -61,10 +66,10 @@ if (url) {
       [await dnsTLDResolverV1.read.gatewayURL()],
       ["x-batch-gateway:true"],
     ]);
-    for (const name of new Set(KNOWN.map((x) => getLabelAt(x.name, -1)))) {
+    for (const name of ["dnsname.ens.eth"]) {
       await mainnetV2.setupName({
         name,
-        resolverAddress: dnsTLDResolver.address,
+        resolverAddress: await ensRegistry.read.resolver([namehash(name)]),
       });
     }
     return {
@@ -77,19 +82,45 @@ if (url) {
   }
 
   tests = () => {
-    for (const kp of KNOWN) {
-      it(kp.name, async () => {
-        const F = await chain.networkHelpers.loadFixture(fixture);
-        const bundle = bundleCalls(makeResolutions(kp));
-        const [answer, resolver] =
-          await F.mainnetV2.universalResolver.read.resolve([
-            dnsEncodeName(kp.name),
-            bundle.call,
-          ]);
-        expectVar({ resolver }).toEqualAddress(F.dnsTLDResolver.address);
-        bundle.expect(answer);
-      });
-    }
+    const timeout = 15000;
+    describe("v1", () => {
+      for (const kp of KNOWN) {
+        it(kp.name, { timeout }, async () => {
+          const F = await chain.networkHelpers.loadFixture(fixture);
+          await F.mainnetV2.setupName({
+            name: getLabelAt(kp.name, -1),
+            resolverAddress: F.dnsTLDResolverV1.address,
+          });
+          const bundle = bundleCalls(makeResolutions(kp));
+          const [answer, resolver] =
+            await F.mainnetV2.universalResolver.read.resolve([
+              dnsEncodeName(kp.name),
+              bundle.call,
+            ]);
+          expectVar({ resolver }).toEqualAddress(F.dnsTLDResolverV1.address);
+          bundle.expect(answer);
+        });
+      }
+    });
+    describe("v2", () => {
+      for (const kp of KNOWN) {
+        it(kp.name, { timeout }, async () => {
+          const F = await chain.networkHelpers.loadFixture(fixture);
+          await F.mainnetV2.setupName({
+            name: getLabelAt(kp.name, -1),
+            resolverAddress: F.dnsTLDResolver.address,
+          });
+          const bundle = bundleCalls(makeResolutions(kp));
+          const [answer, resolver] =
+            await F.mainnetV2.universalResolver.read.resolve([
+              dnsEncodeName(kp.name),
+              bundle.call,
+            ]);
+          expectVar({ resolver }).toEqualAddress(F.dnsTLDResolver.address);
+          bundle.expect(answer);
+        });
+      }
+    });
   };
 }
 

--- a/contracts/test/dns/DNSTLDResolver.t.sol
+++ b/contracts/test/dns/DNSTLDResolver.t.sol
@@ -7,6 +7,7 @@ import {DNSTLDResolver, ENS, IRegistry, DNSSEC, HexUtils} from "../../src/L1/dns
 import {PermissionedRegistry, IRegistryMetadata} from "../../src/common/PermissionedRegistry.sol";
 import {RegistryDatastore} from "../../src/common/RegistryDatastore.sol";
 import {LibEACBaseRoles} from "../../src/common/EnhancedAccessControl.sol";
+import {IAddrResolver} from "@ens/contracts/resolvers/profiles/IAddrResolver.sol";
 
 // coverage:ignore-next-line
 contract MockDNS is DNSTLDResolver {
@@ -40,7 +41,7 @@ contract MockDNS is DNSTLDResolver {
     }
 }
 
-contract DNSTLDResolverTest is Test, ERC1155Holder {
+contract DNSTLDResolverTest is Test, ERC1155Holder, IAddrResolver {
     RegistryDatastore datastore;
     PermissionedRegistry rootRegistry;
     MockDNS dns;
@@ -107,17 +108,21 @@ contract DNSTLDResolverTest is Test, ERC1155Holder {
         );
     }
 
+	// mock IAddrResolver
+	function addr(bytes32) public pure returns (address payable) {
+		return payable(address(1));
+	}
+
     function test_parseResolver_name() external {
-        address resolver = address(1);
         rootRegistry.register(
             "abc",
             address(this),
             IRegistry(address(0)),
-            resolver,
+            address(this),
             LibEACBaseRoles.ALL_ROLES,
             uint64(block.timestamp) + 86400
         );
-        assertEq(dns.parseResolver("abc"), resolver);
+        assertEq(dns.parseResolver("abc"), addr(bytes32(0)));
     }
 
     function testFuzz_parseResolver_address(address a) external view {

--- a/contracts/test/fixtures/deployV2Fixture.ts
+++ b/contracts/test/fixtures/deployV2Fixture.ts
@@ -50,9 +50,7 @@ export async function deployV2Fixture(
     await networkConnection.viem.deployContract("VerifiableFactory");
   const dedicatedResolverImpl =
     await networkConnection.viem.deployContract("DedicatedResolver");
-  const dedicatedResolver = await deployDedicatedResolver({
-    owner: walletClient.account.address,
-  });
+  const dedicatedResolver = await deployDedicatedResolver();
   return {
     networkConnection,
     publicClient,
@@ -67,12 +65,12 @@ export async function deployV2Fixture(
     setupName,
   };
   async function deployDedicatedResolver({
-    owner,
+    owner = walletClient.account.address,
     salt = BigInt(labelhash(new Date().toISOString())),
   }: {
     owner: Address;
     salt?: bigint;
-  }) {
+  } = {}) {
     const wallet = await networkConnection.viem.getWalletClient(owner);
     const hash = await verifiableFactory.write.deployProxy([
       dedicatedResolverImpl.address,

--- a/contracts/test/fixtures/deployV2Fixture.ts
+++ b/contracts/test/fixtures/deployV2Fixture.ts
@@ -50,7 +50,6 @@ export async function deployV2Fixture(
     await networkConnection.viem.deployContract("VerifiableFactory");
   const dedicatedResolverImpl =
     await networkConnection.viem.deployContract("DedicatedResolver");
-  const dedicatedResolver = await deployDedicatedResolver();
   return {
     networkConnection,
     publicClient,
@@ -60,7 +59,6 @@ export async function deployV2Fixture(
     ethRegistry,
     universalResolver,
     verifiableFactory,
-    dedicatedResolver, // warning: this is owned by the default wallet
     deployDedicatedResolver,
     setupName,
   };
@@ -94,13 +92,17 @@ export async function deployV2Fixture(
     );
   }
   // creates registries up to the parent name
-
-  async function setupName<exact_ extends boolean = false>({
+  // if exact, exactRegistry is setup
+  // if no resolverAddress, dedicatedResolver is deployed
+  async function setupName<
+    exact_ extends boolean = false,
+    resolver_ extends false | Address = false,
+  >({
     name,
     owner = walletClient.account.address,
     expiry = MAX_EXPIRY,
     roles = ROLES.ALL,
-    resolverAddress = dedicatedResolver.address,
+    resolverAddress,
     metadataAddress = zeroAddress,
     exact,
   }: {
@@ -108,12 +110,18 @@ export async function deployV2Fixture(
     owner?: Address;
     expiry?: bigint;
     roles?: bigint;
-    resolverAddress?: Address;
+    resolverAddress?: resolver_ | Address;
     metadataAddress?: Address;
-    exact?: exact_ | undefined;
+    exact?: exact_;
   }) {
     const labels = splitName(name);
     if (!labels.length) throw new Error("expected name");
+    const dedicatedResolver = resolverAddress
+      ? undefined
+      : await deployDedicatedResolver({ owner });
+    if (!resolverAddress) {
+      resolverAddress = dedicatedResolver?.address ?? zeroAddress;
+    }
     const registries = [rootRegistry];
     while (true) {
       const parentRegistry = registries[0];
@@ -128,7 +136,12 @@ export async function deployV2Fixture(
           // registry does not exist, create it
           const registry = await networkConnection.viem.deployContract(
             "PermissionedRegistry",
-            [datastore.address, metadataAddress, walletClient.account.address, roles],
+            [
+              datastore.address,
+              metadataAddress,
+              walletClient.account.address,
+              roles,
+            ],
           );
           registryAddress = registry.address;
           if (exists) {
@@ -167,16 +180,28 @@ export async function deployV2Fixture(
       }
       if (leaf) {
         // invariants:
+        //            tokenId == labelToCanonicalId(labels[0])
         //  registries.length == labels.length
         //     exactRegistry? == registries[0]
         //     parentRegistry == registries[1]
-        //            tokenId == labelToCanonicalId(labels[0])
+        // dedicatedResolver? == !resolverAddress
         return {
           labels,
           tokenId,
           parentRegistry,
-          exactRegistry: exact ? registries[0] : undefined,
-          registries: exact ? registries : [undefined, ...registries],
+          exactRegistry: (exact
+            ? registries[0]
+            : undefined) as exact_ extends true
+            ? (typeof registries)[number]
+            : undefined,
+          registries: (exact
+            ? registries
+            : [undefined, ...registries]) as exact_ extends true
+            ? typeof registries
+            : [undefined, ...typeof registries],
+          dedicatedResolver: dedicatedResolver as resolver_ extends false
+            ? NonNullable<typeof dedicatedResolver>
+            : undefined,
         };
       }
     }

--- a/contracts/test/fixtures/deployV2Fixture.ts
+++ b/contracts/test/fixtures/deployV2Fixture.ts
@@ -68,7 +68,7 @@ export async function deployV2Fixture(
     owner = walletClient.account.address,
     salt = BigInt(labelhash(new Date().toISOString())),
   }: {
-    owner: Address;
+    owner?: Address;
     salt?: bigint;
   } = {}) {
     const wallet = await networkConnection.viem.getWalletClient(owner);


### PR DESCRIPTION
- added [DNSTLDResolver.mainnet.test.ts](https://github.com/ensdomains/namechain/blob/feat/bet-431-forked-dnssec/contracts/test/dns/DNSTLDResolver.mainnet.test.ts)
    * runs if `MAINNET_RPC_URL` is defined
- changed `deployV2Fixture.ts`
    * removed shared `dedicatedResolver` — was dangerous design
    * make `setupName()` deploy a `DedicatedResolver` unless `resolverAddress` is specified
- fixed [DNSTLDResolver.sol](https://github.com/ensdomains/namechain/blob/feat/bet-431-forked-dnssec/contracts/src/L1/dns/DNSTLDResolver.sol#L365-L373) &mdash; it is the `addr(60)` of the resolver, not the resolver itself
- fixed related tests

---
 > `$ MAINNET_RPC_URL=https://eth.drpc.org bun run test:hardhat test/dns/DNSTLDResolver.mainnet.test.ts`