### PR TITLE
Remove expiry from setResolver

### DIFF
--- a/contracts/src/common/BaseRegistry.sol
+++ b/contracts/src/common/BaseRegistry.sol
@@ -67,6 +67,6 @@ abstract contract BaseRegistry is IRegistry, ERC1155Singleton {
      * @return resolver The address of a resolver responsible for this name, or `address(0)` if none exists.
      */
     function getResolver(string calldata label) external view virtual returns (address resolver) {
-        (resolver, ,) = datastore.getResolver(NameUtils.labelToCanonicalId(label));
+        (resolver, ) = datastore.getResolver(NameUtils.labelToCanonicalId(label));
     }
 }

--- a/contracts/src/common/DatastoreUtils.sol
+++ b/contracts/src/common/DatastoreUtils.sol
@@ -11,6 +11,14 @@ library DatastoreUtils {
         packed = (uint256(data) << 224) | (uint256(expiry) << 160) | uint256(uint160(addr));
     }
 
+    /// @dev Pack `(address, data)` together into a word for resolver storage.
+    /// @param addr The address to pack.
+    /// @param data The data to pack.
+    /// @return packed The packed word.
+    function packResolver(address addr, uint32 data) internal pure returns (uint256 packed) {
+        packed = (uint256(data) << 160) | uint256(uint160(addr));
+    }
+
     /// @dev Unpack a word into `(address, expiry, data)`.
     /// @param packed The packed word.
     /// @return addr The packed address.
@@ -20,5 +28,14 @@ library DatastoreUtils {
         addr = address(uint160(packed));
         expiry = uint64(packed >> 160);
         data = uint32(packed >> 224);
+    }
+
+    /// @dev Unpack a resolver word into `(address, data)`.
+    /// @param packed The packed word.
+    /// @return addr The packed address.
+    /// @return data The packed data.
+    function unpackResolver(uint256 packed) internal pure returns (address addr, uint32 data) {
+        addr = address(uint160(packed));
+        data = uint32(packed >> 160);
     }
 }

--- a/contracts/src/common/IRegistryDatastore.sol
+++ b/contracts/src/common/IRegistryDatastore.sol
@@ -14,8 +14,8 @@ interface IRegistryDatastore {
         view
         returns (address subregistry, uint64 expiry, uint32 data);
     function getSubregistry(uint256 id) external view returns (address subregistry, uint64 expiry, uint32 data);
-    function getResolver(address registry, uint256 id) external view returns (address resolver, uint64 expiry, uint32 data);
-    function getResolver(uint256 id) external view returns (address resolver, uint64 expiry, uint32 data);
+    function getResolver(address registry, uint256 id) external view returns (address resolver, uint32 data);
+    function getResolver(uint256 id) external view returns (address resolver, uint32 data);
     function setSubregistry(uint256 id, address subregistry, uint64 expiry, uint32 data) external;
-    function setResolver(uint256 id, address resolver, uint64 expiry, uint32 data) external;
+    function setResolver(uint256 id, address resolver, uint32 data) external;
 }

--- a/contracts/src/common/PermissionedRegistry.sol
+++ b/contracts/src/common/PermissionedRegistry.sol
@@ -21,7 +21,7 @@ import {IEnhancedAccessControl} from "./IEnhancedAccessControl.sol";
 contract PermissionedRegistry is BaseRegistry, EnhancedAccessControl, IPermissionedRegistry, MetadataMixin {
     event TokenRegenerated(uint256 oldTokenId, uint256 newTokenId);
     event SubregistryUpdate(uint256 indexed id, address subregistry, uint64 expiry, uint32 data);
-    event ResolverUpdate(uint256 indexed id, address resolver, uint64 expiry, uint32 data);
+    event ResolverUpdate(uint256 indexed id, address resolver, uint32 data);
 
     mapping(uint256 => ITokenObserver) public tokenObservers;
 
@@ -90,8 +90,8 @@ contract PermissionedRegistry is BaseRegistry, EnhancedAccessControl, IPermissio
         _mint(owner, tokenId, 1, "");
         _grantRoles(getResourceFromTokenId(tokenId), roleBitmap, owner, false);
 
-        datastore.setResolver(tokenId, resolver, 0, 0);
-        emit ResolverUpdate(tokenId, resolver, 0, 0);
+        datastore.setResolver(tokenId, resolver, 0);
+        emit ResolverUpdate(tokenId, resolver, 0);
 
         emit NewSubname(tokenId, label);
 
@@ -132,8 +132,8 @@ contract PermissionedRegistry is BaseRegistry, EnhancedAccessControl, IPermissio
         datastore.setSubregistry(tokenId, address(0), 0, 0);
         emit SubregistryUpdate(tokenId, address(0), 0, 0);
         
-        datastore.setResolver(tokenId, address(0), 0, 0);
-        emit ResolverUpdate(tokenId, address(0), 0, 0);
+        datastore.setResolver(tokenId, address(0), 0);
+        emit ResolverUpdate(tokenId, address(0), 0);
 
         emit NameBurned(tokenId, msg.sender);
     }
@@ -153,7 +153,7 @@ contract PermissionedRegistry is BaseRegistry, EnhancedAccessControl, IPermissio
         if (expires <= block.timestamp) {
             return address(0);
         }
-        (address resolver, , ) = datastore.getResolver(canonicalId);
+        (address resolver, ) = datastore.getResolver(canonicalId);
         return resolver;
     }
 
@@ -172,8 +172,8 @@ contract PermissionedRegistry is BaseRegistry, EnhancedAccessControl, IPermissio
         override
         onlyNonExpiredTokenRoles(tokenId, LibRegistryRoles.ROLE_SET_RESOLVER)
     {
-        datastore.setResolver(tokenId, resolver, 0, 0);
-        emit ResolverUpdate(tokenId, resolver, 0, 0);
+        datastore.setResolver(tokenId, resolver, 0);
+        emit ResolverUpdate(tokenId, resolver, 0);
     }
 
     function getNameData(string calldata label) public view returns (uint256 tokenId, uint64 expiry, uint32 tokenIdVersion) {

--- a/contracts/src/common/RegistryDatastore.sol
+++ b/contracts/src/common/RegistryDatastore.sol
@@ -29,12 +29,12 @@ contract RegistryDatastore is IRegistryDatastore {
     function getResolver(address registry, uint256 id)
         public
         view
-        returns (address resolver, uint64 expiry, uint32 data)
+        returns (address resolver, uint32 data)
     {
-        (resolver, expiry, data) = DatastoreUtils.unpack(entries[registry][NameUtils.getCanonicalId(id)].resolverData);
+        (resolver, data) = DatastoreUtils.unpackResolver(entries[registry][NameUtils.getCanonicalId(id)].resolverData);
     }
 
-    function getResolver(uint256 id) external view returns (address resolver, uint64 expiry, uint32 data) {
+    function getResolver(uint256 id) external view returns (address resolver, uint32 data) {
         return getResolver(msg.sender, id);
     }
 
@@ -43,8 +43,8 @@ contract RegistryDatastore is IRegistryDatastore {
         entries[msg.sender][id].registryData = DatastoreUtils.pack(subregistry, expiry, data);
     }
 
-    function setResolver(uint256 id, address resolver, uint64 expiry, uint32 data) external {
+    function setResolver(uint256 id, address resolver, uint32 data) external {
         id = NameUtils.getCanonicalId(id);
-        entries[msg.sender][id].resolverData = DatastoreUtils.pack(resolver, expiry, data);
+        entries[msg.sender][id].resolverData = DatastoreUtils.packResolver(resolver, data);
     }
 }

--- a/contracts/test/RegistryDatastore.t.sol
+++ b/contracts/test/RegistryDatastore.t.sol
@@ -46,31 +46,27 @@ contract TestRegistryDatastore is Test {
     }
 
     function test_GetSetResolver_MsgSender() public {
-        datastore.setResolver(id, address(this), expiryTime, data);
+        datastore.setResolver(id, address(this), data);
 
-        (address resolver, uint64 expiry, uint32 returnedData) = datastore.getResolver(id);
+        (address resolver, uint32 returnedData) = datastore.getResolver(id);
         vm.assertEq(resolver, address(this));
-        vm.assertEq(expiry, expiryTime);
         vm.assertEq(returnedData, data);
 
-        (resolver, expiry, returnedData) = datastore.getResolver(address(this), id);
+        (resolver, returnedData) = datastore.getResolver(address(this), id);
         vm.assertEq(resolver, address(this));
-        vm.assertEq(expiry, expiryTime);
         vm.assertEq(returnedData, data);
     }
 
     function test_GetSetResolver_OtherRegistry() public {
         DummyRegistry r = new DummyRegistry(datastore);
-        r.setResolver(id, address(this), expiryTime, data);
+        r.setResolver(id, address(this), data);
 
-        (address resolver, uint64 expiry, uint32 returnedData) = datastore.getResolver(id);
+        (address resolver, uint32 returnedData) = datastore.getResolver(id);
         vm.assertEq(resolver, address(0));
-        vm.assertEq(expiry, 0);
         vm.assertEq(returnedData, 0);
 
-        (resolver, expiry, returnedData) = datastore.getResolver(address(r), id);
+        (resolver, returnedData) = datastore.getResolver(address(r), id);
         vm.assertEq(resolver, address(this));
-        vm.assertEq(expiry, expiryTime);
         vm.assertEq(returnedData, data);
     }
 }
@@ -86,7 +82,7 @@ contract DummyRegistry {
         datastore.setSubregistry(id, subregistry, expiry, data);
     }
 
-    function setResolver(uint256 id, address resolver, uint64 expiry, uint32 data) public {
-        datastore.setResolver(id, resolver, expiry, data);
+    function setResolver(uint256 id, address resolver, uint32 data) public {
+        datastore.setResolver(id, resolver, data);
     }
 }


### PR DESCRIPTION
We had `expiry` on setResolver to be consistent with `setSubregistry` but it actually has no use so removing it