### PR TITLE
fix: price oracle deployment

### DIFF
--- a/contracts/deploy/l2/02_PriceOracle.ts
+++ b/contracts/deploy/l2/02_PriceOracle.ts
@@ -1,8 +1,14 @@
 /// we import what we need from the @rocketh alias, see ../rocketh.ts
 import { artifacts, execute } from "@rocketh";
+import {
+  dollarsPerYearToNdpsExact,
+  ndpsToDollarsPerYearStringExact,
+} from "../../test/utils/ndps.ts";
 
-// USD prices in 6 decimals (USDC standard)
-const BASE_PRICE_USD = 10n * 10n**6n;     // $10.00
+// nanodollars per second pricing
+const PRICE_5_CHAR = dollarsPerYearToNdpsExact("5");
+const PRICE_4_CHAR = dollarsPerYearToNdpsExact("160");
+const PRICE_3_CHAR = dollarsPerYearToNdpsExact("640");
 
 export default execute(
   async ({ deploy, namedAccounts, get }) => {
@@ -14,24 +20,25 @@ export default execute(
 
     const tokenAddresses = [mockUSDC.address, mockDAI.address];
     const tokenDecimals = [6, 18]; // USDC: 6 decimals, DAI: 18 decimals
-    const rentPrices = [BASE_PRICE_USD, BASE_PRICE_USD, BASE_PRICE_USD, 0n, 0n]; // Array of rent prices (5 prices for StablePriceOracle)
+    const rentPrices = [PRICE_5_CHAR, PRICE_4_CHAR, PRICE_3_CHAR, 0n, 0n]; // Array of rent prices (5 prices for StablePriceOracle)
 
     // Use the full path to access StablePriceOracle from artifacts
-    const StablePriceOracle = artifacts["src/L2/StablePriceOracle.sol/StablePriceOracle"];
+    const StablePriceOracle =
+      artifacts["src/L2/StablePriceOracle.sol/StablePriceOracle"];
 
     await deploy("PriceOracle", {
       account: deployer,
       artifact: StablePriceOracle,
-      args: [
-        tokenAddresses,
-        tokenDecimals,
-        rentPrices,
-      ],
+      args: [tokenAddresses, tokenDecimals, rentPrices],
     });
 
-    console.log(`✅ TokenPriceOracle deployed with:`)
-    console.log(`   - Base Price: $${Number(BASE_PRICE_USD) / 10**6}`);
-    console.log(`   - Rent Prices: [${rentPrices.map(p => `$${Number(p) / 10**6}`).join(', ')}]`);
+    console.log(`✅ TokenPriceOracle deployed with:`);
+    console.log(
+      `   - Base Price: $${ndpsToDollarsPerYearStringExact(PRICE_5_CHAR)}`,
+    );
+    console.log(
+      `   - Rent Prices: [${rentPrices.map((p) => `$${ndpsToDollarsPerYearStringExact(p)}`).join(", ")}]`,
+    );
     console.log(`   - Supported Tokens:`);
     console.log(`     - MockUSDC (6 decimals): ${tokenAddresses[0]}`);
     console.log(`     - MockDAI (18 decimals): ${tokenAddresses[1]}`);

--- a/contracts/test/utils/ndps.ts
+++ b/contracts/test/utils/ndps.ts
@@ -1,0 +1,68 @@
+type Rounding = "nearest" | "floor" | "ceil";
+
+const SECONDS_PER_YEAR_BI = 31_557_600n; // exact (365.25 * 86400)
+const ND_PER_DOLLAR_BI = 1_000_000_000n; // nanodollars per dollar
+
+function divRound(n: bigint, d: bigint, mode: Rounding): bigint {
+  if (mode === "floor") return n / d;
+  if (mode === "ceil") return (n + d - 1n) / d;
+  // nearest, half-up (inputs assumed non-negative)
+  return (n + d / 2n) / d;
+}
+
+/**
+ * exact: dollars/year (string, up to 9 decimal places) -> nd/s (bigint)
+ * examples of valid inputs: "12", "12.3", "12.345678901"
+ */
+export function dollarsPerYearToNdpsExact(
+  dollarsPerYear: string,
+  rounding: Rounding = "nearest",
+): bigint {
+  const s = dollarsPerYear.trim();
+  if (!/^\d+(\.\d{0,9})?$/.test(s)) {
+    throw new Error("use dollars with up to 9 decimal places");
+  }
+  const [dollars, fracRaw = ""] = s.split(".");
+  const frac = (fracRaw + "000000000").slice(0, 9); // pad to 9 places
+  const ndPerYear = BigInt(dollars) * ND_PER_DOLLAR_BI + BigInt(frac); // already nanodollars
+
+  return divRound(ndPerYear, SECONDS_PER_YEAR_BI, rounding);
+}
+
+const POW10N: readonly bigint[] = [
+  1n,
+  10n,
+  100n,
+  1_000n,
+  10_000n,
+  100_000n,
+  1_000_000n,
+  10_000_000n,
+  100_000_000n,
+  1_000_000_000n,
+];
+
+function formatFixed(n: bigint, decimals: number): string {
+  if (decimals === 0) return n.toString();
+  const base = POW10N[decimals];
+  const i = n / base;
+  const f = (n % base).toString().padStart(decimals, "0");
+  return `${i}.${f}`;
+}
+
+/**
+ * exact: nd/s (bigint) -> $/yr as a decimal string with `decimals` places (0..9)
+ * default 9 decimals gives the exact dollar value since inputs are in nanodollars.
+ */
+export function ndpsToDollarsPerYearStringExact(
+  ndps: bigint,
+  decimals: number = 9,
+  rounding: Rounding = "nearest",
+): string {
+  if (decimals < 0 || decimals > 9) throw new Error("decimals must be 0..9");
+  const ndPerYear = ndps * SECONDS_PER_YEAR_BI; // nanodollars/year (exact)
+  const scaleDown = 9 - decimals; // convert nd -> dollars with N decimals
+  const divisor = POW10N[scaleDown];
+  const scaled = divRound(ndPerYear, divisor, rounding); // integer of dollars * 10^decimals
+  return formatFixed(scaled, decimals);
+}


### PR DESCRIPTION
price oracle was previously being deployed with $5/second pricing for 3/4/5 char names. changed to pre-existing pricing in ENSv1 + added nd/s util funcs