### PR TITLE
Refactor `IRentPriceOracle` from `ETHRegistrar`

### DIFF
--- a/contracts/deploy/l2/01_StandardRentPriceOracle.ts
+++ b/contracts/deploy/l2/01_StandardRentPriceOracle.ts
@@ -1,0 +1,53 @@
+import { artifacts, execute } from "@rocketh";
+import {
+  rateFromAnnualPrice,
+  formatAnnualPriceFromRate,
+  PRICE_DECIMALS,
+} from "../../test/utils/price.ts";
+
+export default execute(
+  async ({ deploy, execute: write, get, namedAccounts: { deployer } }) => {
+    const tokenPriceOracle = get<
+      (typeof artifacts.StableTokenPriceOracle)["abi"]
+    >("StableTokenPriceOracle");
+
+    const MockERC20 = artifacts["src/mocks/MockERC20.sol/MockERC20"];
+    const mockUSDC = get<(typeof MockERC20)["abi"]>("MockUSDC");
+    const mockDAI = get<(typeof MockERC20)["abi"]>("MockDAI");
+
+    const baseRatePerCp = [
+      0n,
+      0n,
+      rateFromAnnualPrice("640"),
+      rateFromAnnualPrice("160"),
+      rateFromAnnualPrice("5"),
+    ] as const;
+
+    console.table(
+      baseRatePerCp.flatMap((rate, i) =>
+        rate
+          ? { cp: 1 + i, rate, yearly: formatAnnualPriceFromRate(rate, 2) }
+          : [],
+      ),
+    );
+
+    const SEC_PER_DAY = 86400n;
+    await deploy("StandardRentPriceOracle", {
+      account: deployer,
+      artifact: artifacts.StandardRentPriceOracle,
+      args: [
+        PRICE_DECIMALS,
+        baseRatePerCp,
+        21n * SEC_PER_DAY, // premiumPeriod
+        SEC_PER_DAY, // premiumHalvingPeriod
+        100_000_000n * 10n ** BigInt(PRICE_DECIMALS), // premiumPriceInitial
+        tokenPriceOracle.address,
+        [mockUSDC.address, mockDAI.address],
+      ],
+    });
+  },
+  {
+    tags: ["StandardRentPriceOracle", "l2"],
+    dependencies: ["MockTokens", "StableTokenPriceOracle"],
+  },
+);

--- a/contracts/deploy/l2/02_ETHRegistrar.ts
+++ b/contracts/deploy/l2/02_ETHRegistrar.ts
@@ -1,10 +1,5 @@
 import { artifacts, execute } from "@rocketh";
 import { ROLES } from "../constants.ts";
-import {
-  rateFromAnnualPrice,
-  formatAnnualPriceFromRate,
-  PRICE_DECIMALS,
-} from "../../test/utils/price.ts";
 
 export default execute(
   async ({
@@ -16,52 +11,24 @@ export default execute(
     const ethRegistry =
       get<(typeof artifacts.PermissionedRegistry)["abi"]>("ETHRegistry");
 
-    const tokenPriceOracle = get<
-      (typeof artifacts.StableTokenPriceOracle)["abi"]
-    >("StableTokenPriceOracle");
-
-    const MockERC20 = artifacts["src/mocks/MockERC20.sol/MockERC20"];
-    const mockUSDC = get<(typeof MockERC20)["abi"]>("MockUSDC");
-    const mockDAI = get<(typeof MockERC20)["abi"]>("MockDAI");
+    const rentPriceOracle = get<(typeof artifacts.IRentPriceOracle)["abi"]>(
+      "StandardRentPriceOracle",
+    );
 
     // Use owner as beneficiary, or deployer if owner is not set
     const beneficiary = owner || deployer;
-
-    const baseRatePerCp = [
-      0n,
-      0n,
-      rateFromAnnualPrice("640"),
-      rateFromAnnualPrice("160"),
-      rateFromAnnualPrice("5"),
-    ] as const;
-
-    console.table(
-      baseRatePerCp.flatMap((rate, i) =>
-        rate
-          ? { cp: 1 + i, rate, yearly: formatAnnualPriceFromRate(rate, 2) }
-          : [],
-      ),
-    );
 
     const SEC_PER_DAY = 86400n;
     const ethRegistrar = await deploy("ETHRegistrar", {
       account: deployer,
       artifact: artifacts.ETHRegistrar,
       args: [
-        {
-          ethRegistry: ethRegistry.address,
-          beneficiary,
-          minCommitmentAge: 60n, // 1 minute,
-          maxCommitmentAge: SEC_PER_DAY,
-          minRegistrationDuration: 28n * SEC_PER_DAY,
-          priceDecimals: PRICE_DECIMALS,
-          tokenPriceOracle: tokenPriceOracle.address,
-          baseRatePerCp,
-          premiumPeriod: 21n * SEC_PER_DAY,
-          premiumHalvingPeriod: SEC_PER_DAY,
-          premiumPriceInitial: 100_000_000n * 10n ** BigInt(PRICE_DECIMALS),
-          paymentTokens: [mockUSDC.address, mockDAI.address],
-        },
+        ethRegistry.address,
+        beneficiary,
+        60n, // minCommitmentAge
+        SEC_PER_DAY, // maxCommitmentAge
+        28n * SEC_PER_DAY, // minRegistrationDuration
+        rentPriceOracle.address,
       ],
     });
 
@@ -75,7 +42,7 @@ export default execute(
     });
   },
   {
-    tags: ["ETHRegistrar", "registry", "l2"],
-    dependencies: ["ETHRegistry", "MockTokens", "StableTokenPriceOracle"],
+    tags: ["ETHRegistrar", "l2"],
+    dependencies: ["ETHRegistry", "StandardRentPriceOracle"],
   },
 );

--- a/contracts/src/L2/ETHRegistrar.sol
+++ b/contracts/src/L2/ETHRegistrar.sol
@@ -92,15 +92,15 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
         IERC20Metadata paymentToken
     ) public view returns (uint256 base, uint256 premium) {
         (uint256 tokenId, uint64 expiry, ) = registry.getNameData(label);
-        (base, premium) = rentPriceOracle.rentPrice(
-            label,
-            expiry,
-            duration,
-            paymentToken
-        );
-        if (owner != address(0) && owner == registry.latestOwnerOf(tokenId)) {
-            premium = 0;
-        }
+        return
+            rentPriceOracle.rentPrice(
+                label,
+                owner != address(0) && owner == registry.latestOwnerOf(tokenId)
+                    ? 0
+                    : expiry,
+                duration,
+                paymentToken
+            );
     }
 
     /// @inheritdoc IETHRegistrar

--- a/contracts/src/L2/ETHRegistrar.sol
+++ b/contracts/src/L2/ETHRegistrar.sol
@@ -1,19 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {IETHRegistrar} from "./IETHRegistrar.sol";
-import {ITokenPriceOracle} from "./ITokenPriceOracle.sol";
+import {IRentPriceOracle} from "./IRentPriceOracle.sol";
 import {IRegistry} from "../common/IRegistry.sol";
 import {IPermissionedRegistry} from "../common/IPermissionedRegistry.sol";
 import {EnhancedAccessControl, LibEACBaseRoles} from "../common/EnhancedAccessControl.sol";
 import {LibRegistryRoles} from "../common/LibRegistryRoles.sol";
-import {StringUtils} from "@ens/contracts/utils/StringUtils.sol";
-import {PriceUtils} from "../common/PriceUtils.sol";
 
 uint256 constant REGISTRATION_ROLE_BITMAP = LibRegistryRoles
     .ROLE_SET_SUBREGISTRY |
@@ -21,39 +16,30 @@ uint256 constant REGISTRATION_ROLE_BITMAP = LibRegistryRoles
     LibRegistryRoles.ROLE_SET_RESOLVER |
     LibRegistryRoles.ROLE_SET_RESOLVER_ADMIN;
 
-contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
-    struct ConstructorArgs {
-        IPermissionedRegistry ethRegistry;
-        address beneficiary;
-        uint64 minCommitmentAge;
-        uint64 maxCommitmentAge;
-        uint64 minRegistrationDuration;
-        uint8 priceDecimals;
-        uint256[5] baseRatePerCp;
-        uint64 premiumPeriod;
-        uint64 premiumHalvingPeriod;
-        uint256 premiumPriceInitial;
-        ITokenPriceOracle tokenPriceOracle;
-        IERC20Metadata[] paymentTokens;
-    }
+uint256 constant ROLE_SET_ORACLE = 1 << 0;
 
-    IPermissionedRegistry public immutable ethRegistry; // [register, expiry)
+contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
+    IPermissionedRegistry public immutable registry; // [register, expiry)
     address public immutable beneficiary;
     uint64 public immutable minCommitmentAge; // [min, max)
     uint64 public immutable maxCommitmentAge;
-    uint64 public immutable minRegistrationDuration; // [min, inf)
-    uint8 public immutable priceDecimals;
-    uint256[5] baseRatePerCp; // rate = price/sec
-    uint64 public immutable premiumPeriod;
-    uint64 public immutable premiumHalvingPeriod;
-    uint256 public immutable premiumPriceInitial;
-    uint256 public immutable premiumPriceOffset;
-    ITokenPriceOracle public immutable tokenPriceOracle;
-    mapping(IERC20Metadata => bool) _isPaymentToken;
+    uint64 public immutable minRegisterDuration; // [min, inf)
+    uint64 public immutable minRenewDuration; // [min, inf)
+    IRentPriceOracle public rentPriceOracle;
+
     mapping(bytes32 => uint64) _commitTime;
 
-    constructor(ConstructorArgs memory args) {
-        if (args.maxCommitmentAge <= args.minCommitmentAge) {
+    event RentPriceOracleChanged();
+
+    constructor(
+        IPermissionedRegistry _registry,
+        address _beneficiary,
+        uint64 _minCommitmentAge,
+        uint64 _maxCommitmentAge,
+        uint64 _minRegisterDuration,
+        IRentPriceOracle _rentPriceOracle
+    ) {
+        if (_maxCommitmentAge <= _minCommitmentAge) {
             revert MaxCommitmentAgeTooLow();
         }
         _grantRoles(
@@ -62,27 +48,15 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
             _msgSender(),
             true
         );
-        ethRegistry = args.ethRegistry;
-        beneficiary = args.beneficiary;
-        minCommitmentAge = args.minCommitmentAge;
-        maxCommitmentAge = args.maxCommitmentAge;
-        minRegistrationDuration = args.minRegistrationDuration;
-        priceDecimals = args.priceDecimals;
-        baseRatePerCp = args.baseRatePerCp;
-        premiumPeriod = args.premiumPeriod;
-        premiumHalvingPeriod = args.premiumHalvingPeriod;
-        premiumPriceInitial = args.premiumPriceInitial;
-        premiumPriceOffset = PriceUtils.halving(
-            args.premiumPriceInitial,
-            args.premiumHalvingPeriod,
-            args.premiumPeriod
-        );
-        tokenPriceOracle = args.tokenPriceOracle;
-        for (uint256 i; i < args.paymentTokens.length; i++) {
-            _setPaymentToken(args.paymentTokens[i], true);
-        }
+        registry = _registry;
+        beneficiary = _beneficiary;
+        minCommitmentAge = _minCommitmentAge;
+        maxCommitmentAge = _maxCommitmentAge;
+        minRegisterDuration = _minRegisterDuration;
+        rentPriceOracle = _rentPriceOracle;
     }
 
+    /// @inheritdoc EnhancedAccessControl
     function supportsInterface(
         bytes4 interfaceId
     ) public view override(EnhancedAccessControl) returns (bool) {
@@ -91,109 +65,24 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
             super.supportsInterface(interfaceId);
     }
 
-    // function setPaymentToken(IERC20Metadata paymentToken, bool supported) external onlyRootRoles(LibRegistryRoles.ROLE_CONFIGURE_ADMIN) {
-    // 	_setPaymentToken(token, supported);
-    // }
-
-    /// @dev Internal logic for enabling a payment token.
-    function _setPaymentToken(
-        IERC20Metadata paymentToken,
-        bool supported
-    ) internal {
-        _isPaymentToken[paymentToken] = supported;
-        emit PaymentTokenChanged(paymentToken, supported);
-    }
-
-    modifier onlyPaymentToken(IERC20Metadata paymentToken) {
-        if (!_isPaymentToken[paymentToken]) {
-            revert PaymentTokenNotSupported(paymentToken);
-        }
-        _;
+    /// @dev Change the rent price oracle.
+    function setRentPriceOracle(
+        IRentPriceOracle oracle
+    ) external onlyRootRoles(ROLE_SET_ORACLE) {
+        rentPriceOracle = oracle;
+        emit RentPriceOracleChanged();
     }
 
     /// @inheritdoc IETHRegistrar
     function isPaymentToken(
         IERC20Metadata paymentToken
     ) external view returns (bool) {
-        return _isPaymentToken[paymentToken];
+        return rentPriceOracle.isPaymentToken(paymentToken);
     }
 
     /// @inheritdoc IETHRegistrar
-    function isValid(string memory label) external pure returns (bool) {
-        return _isValidLength(StringUtils.strlen(label));
-    }
-
-    /// @dev Internal logic for valid label length.
-    function _isValidLength(uint256 ncp) internal pure returns (bool) {
-        return ncp >= 3;
-    }
-
-    /// @inheritdoc IETHRegistrar
-    function isAvailable(string memory label) external view returns (bool) {
-        (, uint64 expiry, ) = ethRegistry.getNameData(label);
-        return _isAvailable(expiry);
-    }
-
-    /// @dev Internal logic for registration availability.
-    function _isAvailable(uint256 expiry) internal view returns (bool) {
-        return block.timestamp >= expiry;
-    }
-
-    /// @notice Get base price to register or renew `label` for `duration`.
-    ///         Use `duration = 1` for rate (price/sec).
-    /// @param label The name to price.
-    /// @param duration The duration to price, in seconds.
-    /// @return The base price.
-    function basePrice(
-        string memory label,
-        uint64 duration
-    ) public view returns (uint256) {
-        uint256 ncp = StringUtils.strlen(label);
-        if (!_isValidLength(ncp)) {
-            revert NoRentPrice(label);
-        }
-        uint256 baseRate = baseRatePerCp[
-            (ncp > baseRatePerCp.length ? baseRatePerCp.length : ncp) - 1
-        ];
-        return baseRate * duration;
-    }
-
-    /// @notice Get premium price for a duration after expiry.
-    ///         Positive over `[0, premiumPeriod)`.
-    /// @param duration The time after expiration, in seconds.
-    /// @return The premium price.
-    function premiumPriceAfter(uint64 duration) public view returns (uint256) {
-        if (duration >= premiumPeriod) return 0;
-        return
-            PriceUtils.halving(
-                premiumPriceInitial,
-                premiumHalvingPeriod,
-                duration
-            ) - premiumPriceOffset;
-    }
-
-    /// @notice Get premium price for a name.
-    ///         Waived if `owner` was the latest owner.
-    /// @param label The name to price.
-    /// @param owner The owner for the registration.
-    /// @return The premium price.
-    function premiumPrice(
-        string memory label,
-        address owner
-    ) public view returns (uint256) {
-        (uint256 tokenId, uint64 expiry, ) = ethRegistry.getNameData(label);
-        return
-            owner != address(0) && owner == ethRegistry.latestOwnerOf(tokenId)
-                ? 0
-                : _premiumPriceFromExpiry(expiry);
-    }
-
-    /// @dev Get premium price for an expiry relative to now.
-    function _premiumPriceFromExpiry(
-        uint64 expiry
-    ) internal view returns (uint256) {
-        uint64 t = uint64(block.timestamp);
-        return t >= expiry ? premiumPriceAfter(t - expiry) : 0;
+    function isValid(string memory label) external view returns (bool) {
+        return rentPriceOracle.isValid(label);
     }
 
     /// @inheritdoc IETHRegistrar
@@ -202,21 +91,28 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
         address owner,
         uint64 duration,
         IERC20Metadata paymentToken
-    )
-        public
-        view
-        onlyPaymentToken(paymentToken)
-        returns (uint256 base, uint256 premium)
-    {
-        premium = premiumPrice(label, owner);
-        uint256 total = basePrice(label, duration) + premium;
-        uint256 amount = tokenPriceOracle.getTokenAmount(
-            total,
-            priceDecimals,
+    ) public view returns (uint256 base, uint256 premium) {
+        (uint256 tokenId, uint64 expiry, ) = registry.getNameData(label);
+        (base, premium) = rentPriceOracle.rentPrice(
+            label,
+            expiry,
+            duration,
             paymentToken
         );
-        premium = Math.mulDiv(amount, premium, total);
-        base = amount - premium; // ensure: f(a+b) - f(a) == f(b)
+        if (owner != address(0) && owner == registry.latestOwnerOf(tokenId)) {
+            premium = 0;
+        }
+    }
+
+    /// @inheritdoc IETHRegistrar
+    function isAvailable(string memory label) external view returns (bool) {
+        (, uint64 expiry, ) = registry.getNameData(label);
+        return _isAvailable(expiry);
+    }
+
+    /// @dev Internal logic for registration availability.
+    function _isAvailable(uint256 expiry) internal view returns (bool) {
+        return block.timestamp >= expiry;
     }
 
     /// @inheritdoc IETHRegistrar
@@ -273,13 +169,13 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
         uint64 duration,
         IERC20Metadata paymentToken,
         bytes32 referer
-    ) external onlyPaymentToken(paymentToken) returns (uint256 tokenId) {
-        (, uint64 oldExpiry, ) = ethRegistry.getNameData(label);
+    ) external returns (uint256 tokenId) {
+        (, uint64 oldExpiry, ) = registry.getNameData(label);
         if (!_isAvailable(oldExpiry)) {
             revert NameAlreadyRegistered(label);
         }
-        if (duration < minRegistrationDuration) {
-            revert DurationTooShort(duration, minRegistrationDuration);
+        if (duration < minRegisterDuration) {
+            revert DurationTooShort(duration, minRegisterDuration);
         }
         _consumeCommitment(
             makeCommitment(
@@ -296,20 +192,15 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
             owner,
             duration,
             paymentToken
-        ); // reverts if !isValid()
-        SafeERC20.safeTransferFrom(
-            paymentToken,
-            _msgSender(),
-            beneficiary,
-            base + premium
-        ); // reverts if payment failed
-        tokenId = ethRegistry.register(
+        ); // reverts if !isValid or !isPaymentToken
+        paymentToken.transferFrom(_msgSender(), beneficiary, base + premium); // reverts if payment failed
+        tokenId = registry.register(
             label,
             owner,
             subregistry,
             resolver,
             REGISTRATION_ROLE_BITMAP,
-            uint64(block.timestamp) + duration
+            _addDuration(uint64(block.timestamp), duration)
         ); // reverts if owner is null
         emit NameRegistered(
             tokenId,
@@ -331,29 +222,23 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
         uint64 duration,
         IERC20Metadata paymentToken,
         bytes32 referer
-    ) external onlyPaymentToken(paymentToken) {
-        (uint256 tokenId, uint64 oldExpiry, ) = ethRegistry.getNameData(label);
+    ) external {
+        (uint256 tokenId, uint64 oldExpiry, ) = registry.getNameData(label);
         if (_isAvailable(oldExpiry)) {
             revert NameNotRegistered(label);
         }
-        // Check for overflow before any state changes
-        if (oldExpiry > type(uint64).max - duration) {
-            revert DurationOverflow(oldExpiry, duration);
+        if (duration == 0) {
+            revert DurationTooShort(duration, 1); /// ???
         }
+        uint64 expires = _addDuration(oldExpiry, duration);
         (uint256 base, ) = rentPrice(
             label,
-            ethRegistry.ownerOf(tokenId),
+            registry.ownerOf(tokenId),
             duration,
             paymentToken
-        );
-        SafeERC20.safeTransferFrom(
-            paymentToken,
-            _msgSender(),
-            beneficiary,
-            base
-        );
-        uint64 expires = oldExpiry + duration;
-        ethRegistry.renew(tokenId, expires);
+        ); // reverts if !isValid or !isPaymentToken
+        paymentToken.transferFrom(_msgSender(), beneficiary, base); // reverts if payment failed
+        registry.renew(tokenId, expires);
         emit NameRenewed(
             tokenId,
             label,
@@ -363,5 +248,18 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
             referer,
             base
         );
+    }
+
+    /// @dev Ensure `expiry + duration` does not overflow.
+    function _addDuration(
+        uint64 expiry,
+        uint64 duration
+    ) internal pure returns (uint64 sum) {
+        unchecked {
+            sum = expiry + duration;
+        }
+        if (sum < expiry) {
+            revert DurationOverflow(expiry, duration);
+        }
     }
 }

--- a/contracts/src/L2/ETHRegistrar.sol
+++ b/contracts/src/L2/ETHRegistrar.sol
@@ -24,7 +24,6 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
     uint64 public immutable minCommitmentAge; // [min, max)
     uint64 public immutable maxCommitmentAge;
     uint64 public immutable minRegisterDuration; // [min, inf)
-    uint64 public immutable minRenewDuration; // [min, inf)
     IRentPriceOracle public rentPriceOracle;
 
     mapping(bytes32 => uint64) _commitTime;
@@ -228,7 +227,7 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
             revert NameNotRegistered(label);
         }
         if (duration == 0) {
-            revert DurationTooShort(duration, 1); /// ???
+            revert DurationTooShort(duration, 1); // minRenewDuration?
         }
         uint64 expires = _addDuration(oldExpiry, duration);
         (uint256 base, ) = rentPrice(
@@ -250,7 +249,7 @@ contract ETHRegistrar is IETHRegistrar, EnhancedAccessControl {
         );
     }
 
-    /// @dev Ensure `expiry + duration` does not overflow.
+    /// @dev Assert `expiry + duration` does not overflow.
     function _addDuration(
         uint64 expiry,
         uint64 duration

--- a/contracts/src/L2/IETHRegistrar.sol
+++ b/contracts/src/L2/IETHRegistrar.sol
@@ -5,7 +5,7 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 
 import {IRegistry} from "../common/IRegistry.sol";
 
-/// @notice Interface for the ".eth" registrar which manages registration/renewal for ".eth" registry.
+/// @notice Interface for the ".eth" registrar which manages the ".eth" registry.
 /// @dev Interface selector: `0x9daffb72`
 interface IETHRegistrar {
     /// @notice `label` is not registered.
@@ -177,7 +177,7 @@ interface IETHRegistrar {
     ) external returns (uint256);
 
     /// @notice Renew an existing registration.
-    /// @dev Emits `NameRenewed` or
+    /// @dev Emits `NameRenewed` or reverts with a variety of errors.
     /// @param label The name to renew.
     /// @param duration The registration extension, in seconds.
     /// @param paymentToken The ERC-20 to use for payment.

--- a/contracts/src/L2/IETHRegistrar.sol
+++ b/contracts/src/L2/IETHRegistrar.sol
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {IRegistry} from "../common/IRegistry.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-/// @notice Interface for the ".eth" registrar which manages registration/renewal for ".eth" registry.
-/// @dev Interface selector: `0xa3839be4`
-interface IETHRegistrar {
-    /// @notice `label` has no rent price.
-    /// @dev Error selector: `0x90ecde1b`
-    error NoRentPrice(string label);
+import {IRegistry} from "../common/IRegistry.sol";
 
+/// @notice Interface for the ".eth" registrar which manages registration/renewal for ".eth" registry.
+/// @dev Interface selector: `0x9daffb72`
+interface IETHRegistrar {
     /// @notice `label` is not registered.
     /// @dev Error selector: `0xf2b502e2`
     error NameNotRegistered(string label);
@@ -18,10 +15,6 @@ interface IETHRegistrar {
     /// @notice `label is already registered.
     /// @dev Error selector: `0x6dbb87d0`
     error NameAlreadyRegistered(string label);
-
-    /// @notice `paymentToken` is not supported for payment.
-    /// @dev Error selector: `0x02e2ae9e`
-    error PaymentTokenNotSupported(IERC20Metadata paymentToken);
 
     /// @notice `duration + expiry` overflows.
     /// @dev Error selector: `0x674a4652`
@@ -54,9 +47,6 @@ interface IETHRegistrar {
         uint64 validTo,
         uint64 blockTimestamp
     );
-
-    /// @notice Support for `paymentToken` has changed.
-    event PaymentTokenChanged(IERC20Metadata paymentToken, bool supported);
 
     /// @notice `commitment` was recorded onchain at `block.timestamp`.
     /// @param commitment The commitment hash from `makeCommitment()`.

--- a/contracts/src/L2/IRentPriceOracle.sol
+++ b/contracts/src/L2/IRentPriceOracle.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+/// @dev Interface selector: `0x678a6296`.
+interface IRentPriceOracle {
+    /// @notice `label` has no rent price.
+    /// @dev Error selector: `0x58832032`
+    error NotRentable(string label);
+
+    /// @notice `paymentToken` is not supported for payment.
+    /// @dev Error selector: `0x02e2ae9e`
+    error PaymentTokenNotSupported(IERC20Metadata paymentToken);
+
+    /// @notice Check if `paymentToken` is accepted for payment.
+    /// @param paymentToken The ERC20 to check.
+    /// @return `true` if `paymentToken` is accepted.
+    function isPaymentToken(
+        IERC20Metadata paymentToken
+    ) external view returns (bool);
+
+    /// @notice Check if a `label` is rentable.
+    /// @param label The name.
+    /// @return `true` if the `label` is valid.
+    function isValid(string memory label) external view returns (bool);
+
+    /// @notice Get rent price for `label`.
+    /// @param label The name.
+    /// @param expiry The latest expiry, in seconds.
+    /// @param duration The duration to price, in seconds.
+    /// @param paymentToken The ERC-20 to use.
+    /// @return base The base price, relative to `paymentToken`.
+    /// @return premium The premium price, relative to `paymentToken`.
+    function rentPrice(
+        string memory label,
+        uint64 expiry,
+        uint64 duration,
+        IERC20Metadata paymentToken
+    ) external view returns (uint256 base, uint256 premium);
+}

--- a/contracts/src/L2/IRentPriceOracle.sol
+++ b/contracts/src/L2/IRentPriceOracle.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.13;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
+/// @notice Interface for pricing registration and renewals.
 /// @dev Interface selector: `0x678a6296`.
 interface IRentPriceOracle {
     /// @notice `label` has no rent price.
@@ -26,6 +27,7 @@ interface IRentPriceOracle {
     function isValid(string memory label) external view returns (bool);
 
     /// @notice Get rent price for `label`.
+    /// @dev Reverts `PaymentTokenNotSupported` or `NotRentable`.
     /// @param label The name.
     /// @param expiry The latest expiry, in seconds.
     /// @param duration The duration to price, in seconds.

--- a/contracts/src/L2/StandardRentPriceOracle.sol
+++ b/contracts/src/L2/StandardRentPriceOracle.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {StringUtils} from "@ens/contracts/utils/StringUtils.sol";
+import {IRentPriceOracle} from "./IRentPriceOracle.sol";
+import {ITokenPriceOracle} from "./ITokenPriceOracle.sol";
+import {HalvingUtils} from "../common/HalvingUtils.sol";
+
+contract StandardRentPriceOracle is ERC165, IRentPriceOracle {
+    uint8 public immutable priceDecimals;
+    uint256[5] baseRatePerCp; // rate = price/sec
+    uint64 public immutable premiumPeriod;
+    uint64 public immutable premiumHalvingPeriod;
+    uint256 public immutable premiumPriceInitial;
+    uint256 public immutable premiumPriceOffset;
+    ITokenPriceOracle public immutable tokenPriceOracle;
+    mapping(IERC20Metadata => bool) _isPaymentToken;
+
+    constructor(
+        uint8 _priceDecimals,
+        uint256[5] memory _baseRatePerCp,
+        uint64 _premiumPeriod,
+        uint64 _premiumHalvingPeriod,
+        uint256 _premiumPriceInitial,
+        ITokenPriceOracle _tokenPriceOracle,
+        IERC20Metadata[] memory _paymentTokens
+    ) {
+        priceDecimals = _priceDecimals;
+        baseRatePerCp = _baseRatePerCp;
+        premiumPeriod = _premiumPeriod;
+        premiumHalvingPeriod = _premiumHalvingPeriod;
+        premiumPriceInitial = _premiumPriceInitial;
+        premiumPriceOffset = HalvingUtils.halving(
+            _premiumPriceInitial,
+            _premiumHalvingPeriod,
+            _premiumPeriod
+        );
+        tokenPriceOracle = _tokenPriceOracle;
+        for (uint256 i; i < _paymentTokens.length; i++) {
+            _isPaymentToken[_paymentTokens[i]] = true;
+        }
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view override returns (bool) {
+        return
+            interfaceId == type(IRentPriceOracle).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IRentPriceOracle
+    function isPaymentToken(
+        IERC20Metadata paymentToken
+    ) external view returns (bool) {
+        return _isPaymentToken[paymentToken];
+    }
+
+    /// @inheritdoc IRentPriceOracle
+    /// @notice Does not check if normalized.
+    function isValid(string memory label) external view returns (bool) {
+        return baseRate(label) > 0;
+    }
+
+    /// @inheritdoc IRentPriceOracle
+    function rentPrice(
+        string memory label,
+        uint64 expiry,
+        uint64 duration,
+        IERC20Metadata paymentToken
+    ) public view returns (uint256 base, uint256 premium) {
+        if (!_isPaymentToken[paymentToken]) {
+            revert PaymentTokenNotSupported(paymentToken);
+        }
+        base = baseRate(label);
+        if (base == 0) {
+            revert NotRentable(label);
+        }
+        premium = premiumPrice(expiry);
+        uint256 total = base * duration + premium; // revert on overflow
+        uint256 amount = tokenPriceOracle.getTokenAmount(
+            total,
+            priceDecimals,
+            paymentToken
+        );
+        premium = Math.mulDiv(amount, premium, total);
+        base = amount - premium; // ensure: f(a+b) - f(a) == f(b)
+    }
+
+    /// @notice Get base rate to register or renew `label` for 1 second.
+    /// @param label The name to price.
+    /// @return The base rate or 0 if not rentable.
+    function baseRate(string memory label) public view returns (uint256) {
+        uint256 ncp = StringUtils.strlen(label);
+        return
+            ncp == 0
+                ? 0
+                : baseRatePerCp[
+                    (ncp > baseRatePerCp.length ? baseRatePerCp.length : ncp) -
+                        1
+                ];
+    }
+
+    /// @notice Get premium price for an expiry relative to now.
+    function premiumPrice(uint64 expiry) public view returns (uint256) {
+        uint64 t = uint64(block.timestamp);
+        return t >= expiry ? premiumPriceAfter(t - expiry) : 0;
+    }
+
+    /// @notice Get premium price for a duration after expiry.
+    ///         Positive over `[0, premiumPeriod)`.
+    /// @param duration The time after expiration, in seconds.
+    /// @return The premium price.
+    function premiumPriceAfter(uint64 duration) public view returns (uint256) {
+        return
+            duration >= premiumPeriod
+                ? 0
+                : HalvingUtils.halving(
+                    premiumPriceInitial,
+                    premiumHalvingPeriod,
+                    duration
+                ) - premiumPriceOffset;
+    }
+}

--- a/contracts/src/L2/StandardRentPriceOracle.sol
+++ b/contracts/src/L2/StandardRentPriceOracle.sol
@@ -97,13 +97,11 @@ contract StandardRentPriceOracle is ERC165, IRentPriceOracle {
     /// @return The base rate or 0 if not rentable.
     function baseRate(string memory label) public view returns (uint256) {
         uint256 ncp = StringUtils.strlen(label);
+        if (ncp == 0) return 0;
         return
-            ncp == 0
-                ? 0
-                : baseRatePerCp[
-                    (ncp > baseRatePerCp.length ? baseRatePerCp.length : ncp) -
-                        1
-                ];
+            baseRatePerCp[
+                (ncp > baseRatePerCp.length ? baseRatePerCp.length : ncp) - 1
+            ];
     }
 
     /// @notice Get premium price for an expiry relative to now.
@@ -117,13 +115,12 @@ contract StandardRentPriceOracle is ERC165, IRentPriceOracle {
     /// @param duration The time after expiration, in seconds.
     /// @return The premium price.
     function premiumPriceAfter(uint64 duration) public view returns (uint256) {
+        if (duration >= premiumPeriod) return 0;
         return
-            duration >= premiumPeriod
-                ? 0
-                : HalvingUtils.halving(
-                    premiumPriceInitial,
-                    premiumHalvingPeriod,
-                    duration
-                ) - premiumPriceOffset;
+            HalvingUtils.halving(
+                premiumPriceInitial,
+                premiumHalvingPeriod,
+                duration
+            ) - premiumPriceOffset;
     }
 }

--- a/contracts/src/common/HalvingUtils.sol
+++ b/contracts/src/common/HalvingUtils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-library PriceUtils {
+library HalvingUtils {
     uint256 constant PRECISION = 1e18;
     uint256 constant bit1 = 999989423469314432; // 0.5 ^ 1/65536 * (10 ** 18)
     uint256 constant bit2 = 999978847050491904; // 0.5 ^ 2/65536 * (10 ** 18)

--- a/contracts/src/common/LibRegistryRoles.sol
+++ b/contracts/src/common/LibRegistryRoles.sol
@@ -9,19 +9,14 @@ library LibRegistryRoles {
     uint256 internal constant ROLE_RENEW_ADMIN = ROLE_RENEW << 128;
 
     uint256 internal constant ROLE_SET_SUBREGISTRY = 1 << 8;
-    uint256 internal constant ROLE_SET_SUBREGISTRY_ADMIN =
-        ROLE_SET_SUBREGISTRY << 128;
+    uint256 internal constant ROLE_SET_SUBREGISTRY_ADMIN = ROLE_SET_SUBREGISTRY << 128;
 
     uint256 internal constant ROLE_SET_RESOLVER = 1 << 12;
-    uint256 internal constant ROLE_SET_RESOLVER_ADMIN =
-        ROLE_SET_RESOLVER << 128;
+    uint256 internal constant ROLE_SET_RESOLVER_ADMIN = ROLE_SET_RESOLVER << 128;
 
     uint256 internal constant ROLE_SET_TOKEN_OBSERVER = 1 << 16;
-    uint256 internal constant ROLE_SET_TOKEN_OBSERVER_ADMIN =
-        ROLE_SET_TOKEN_OBSERVER << 128;
+    uint256 internal constant ROLE_SET_TOKEN_OBSERVER_ADMIN = ROLE_SET_TOKEN_OBSERVER << 128;
 
     uint256 internal constant ROLE_BURN = 1 << 20;
     uint256 internal constant ROLE_BURN_ADMIN = ROLE_BURN << 128;
-
-    //uint256 internal constant ROLE_CONFIGURE_ADMIN = 252;
 }

--- a/contracts/test/ETHRegistrar.t.sol
+++ b/contracts/test/ETHRegistrar.t.sol
@@ -35,7 +35,6 @@ contract TestETHRegistrar is Test {
     address beneficiary = makeAddr("beneficiary");
 
     uint64 constant SEC_PER_YEAR = 31_557_600; // 365.25
-
     uint8 constant PRICE_DECIMALS = 12;
     uint256 constant PRICE_SCALE = 10 ** PRICE_DECIMALS;
     uint256 constant RATE_5_CHAR = (5 * PRICE_SCALE) / SEC_PER_YEAR;
@@ -43,7 +42,6 @@ contract TestETHRegistrar is Test {
     uint256 constant RATE_3_CHAR = (640 * PRICE_SCALE) / SEC_PER_YEAR;
 
     function setUp() external {
-        vm.warp(2_000_000_000); // avoid timestamp issues
 
         datastore = new RegistryDatastore();
 
@@ -91,6 +89,8 @@ contract TestETHRegistrar is Test {
             vm.prank(user);
             token.approve(address(ethRegistrar), type(uint256).max);
         }
+
+        vm.warp(rentPriceOracle.premiumPeriod()); // avoid timestamp issues
     }
 
     function test_Revert_constructor_emptyRange() external {

--- a/contracts/test/HalvingUtils.t.sol
+++ b/contracts/test/HalvingUtils.t.sol
@@ -3,83 +3,86 @@ pragma solidity >=0.8.13;
 
 import "forge-std/Test.sol";
 
-import {PriceUtils} from "../src/common/PriceUtils.sol";
+import {HalvingUtils} from "../src/common/HalvingUtils.sol";
 
-contract TestPriceUtils is Test {
+contract TestHalvingUtils is Test {
     function test_halving_pow2() external pure {
-        for (uint256 i; i < 255; i++) {
-            assertEq(PriceUtils.halving(1 << 255, 1, i), 1 << (255 - i));
+        for (uint256 i; i < 256; i++) {
+            assertEq(HalvingUtils.halving(1 << 255, 1, i), 1 << (255 - i));
         }
     }
 
     function test_halving_computed() external pure {
-        assertEq(PriceUtils.halving(1424499730, 8906, 139967), 26462); // 26465 = -3 => e-4
-        assertEq(PriceUtils.halving(25448394752, 3120, 28344), 46872731); // 46872559 = 172 => e-6
-        assertEq(PriceUtils.halving(226801697741, 2055, 7691), 16944188740); // 16944070054 = 118686 => e-6
-        assertEq(PriceUtils.halving(8346969424321, 2447, 14567), 134739948345); // 134739878463 = 69882 => e-7
-        assertEq(PriceUtils.halving(45287518154421, 3882, 57451), 1588328639); // 1588313410 = 15229 => e-6
+        assertEq(HalvingUtils.halving(1424499730, 8906, 139967), 26462); // 26465 = -3 => e-4
+        assertEq(HalvingUtils.halving(25448394752, 3120, 28344), 46872731); // 46872559 = 172 => e-6
+        assertEq(HalvingUtils.halving(226801697741, 2055, 7691), 16944188740); // 16944070054 = 118686 => e-6
         assertEq(
-            PriceUtils.halving(570920124541253, 9882, 107044),
+            HalvingUtils.halving(8346969424321, 2447, 14567),
+            134739948345
+        ); // 134739878463 = 69882 => e-7
+        assertEq(HalvingUtils.halving(45287518154421, 3882, 57451), 1588328639); // 1588313410 = 15229 => e-6
+        assertEq(
+            HalvingUtils.halving(570920124541253, 9882, 107044),
             313151078238 // 313149809990 = 1268248 => e-6
         );
         assertEq(
-            PriceUtils.halving(7645843420289247, 2217, 5130),
+            HalvingUtils.halving(7645843420289247, 2217, 5130),
             1537665107975056 // 1537661454800508 = 3653174548 => e-6
         );
         assertEq(
-            PriceUtils.halving(41496322237742742, 9631, 138777),
+            HalvingUtils.halving(41496322237742742, 9631, 138777),
             1906996964267 // 1906978706870 = 18257397 => e-6
         );
         assertEq(
-            PriceUtils.halving(324922745063857570, 3699, 14160),
+            HalvingUtils.halving(324922745063857570, 3699, 14160),
             22878240879739585 // 22878035801573052 = 205078166533 => e-6
         );
         assertEq(
-            PriceUtils.halving(7160344361217578864, 376, 2562),
+            HalvingUtils.halving(7160344361217578864, 376, 2562),
             63645461810911484 // 63645361554348369 = 100256563115 => e-6
         );
         assertEq(
-            PriceUtils.halving(48224578080290028571, 4891, 37054),
+            HalvingUtils.halving(48224578080290028571, 4891, 37054),
             252744870505318051 // 252742620367330313 = 2250137987738 => e-6
         );
         assertEq(
-            PriceUtils.halving(105105524861191541746, 6259, 54700),
+            HalvingUtils.halving(105105524861191541746, 6259, 54700),
             245923975222518136 // 245923149907088301 = 825315429835 => e-6
         );
         assertEq(
-            PriceUtils.halving(3099396934116196421933, 3511, 31839),
+            HalvingUtils.halving(3099396934116196421933, 3511, 31839),
             5773426072293995295 // 5773376140217802275 = 49932076193020 => e-6
         );
         assertEq(
-            PriceUtils.halving(26362372193702182792471, 4465, 32623),
+            HalvingUtils.halving(26362372193702182792471, 4465, 32623),
             166549977597448035667 // 166549775208987485845 = 202388460549822 => e-6
         );
         assertEq(
-            PriceUtils.halving(990909067413969805326317, 301, 3338),
+            HalvingUtils.halving(990909067413969805326317, 301, 3338),
             454678187455967549808 // 454675088014747167270 = 3099441220382538 => e-6
         );
         assertEq(
-            PriceUtils.halving(3381740391629922203681908, 715, 10038),
+            HalvingUtils.halving(3381740391629922203681908, 715, 10038),
             200878650042027568241 // 200877705112613028527 = 944929414539714 => e-6
         );
         assertEq(
-            PriceUtils.halving(20690080805932031152205220, 7464, 53584),
+            HalvingUtils.halving(20690080805932031152205220, 7464, 53584),
             142781580193629410427449 // 142780897151513340316761 = 683042116070110688 => e-6
         );
         assertEq(
-            PriceUtils.halving(997325693508064282098634698, 5823, 79101),
+            HalvingUtils.halving(997325693508064282098634698, 5823, 79101),
             81203875465712359043529 // 81203514400252740888790 = 361065459618154739 => e-6
         );
         assertEq(
-            PriceUtils.halving(6654406976005663001193755017, 8615, 128040),
+            HalvingUtils.halving(6654406976005663001193755017, 8615, 128040),
             223392455824911265372939 // 223391340970344010446350 = 1114854567254926589 => e-6
         );
         assertEq(
-            PriceUtils.halving(63990819057295833822937117138, 5696, 9367),
+            HalvingUtils.halving(63990819057295833822937117138, 5696, 9367),
             20468132231412279313226604986 // 20468105475107205357583938901 = 26756305073955642666085 => e-6
         );
         assertEq(
-            PriceUtils.halving(944431998705134667255602102406, 7559, 79787),
+            HalvingUtils.halving(944431998705134667255602102406, 7559, 79787),
             627671476720048668608848886 // 627666858068998984730219320 = 4618651049683878629566 => e-6
         );
     }

--- a/contracts/test/StandardRentPriceOracle.t.sol
+++ b/contracts/test/StandardRentPriceOracle.t.sol
@@ -40,6 +40,8 @@ contract TestRentPriceOracle is Test {
             tokenPriceOracle,
             paymentTokens
         );
+
+        vm.warp(rentPriceOracle.premiumPeriod()); // avoid timestamp issues
     }
 
     function test_supportsInterface() external view {

--- a/contracts/test/StandardRentPriceOracle.t.sol
+++ b/contracts/test/StandardRentPriceOracle.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import "forge-std/Test.sol";
+
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+
+import {StandardRentPriceOracle, IRentPriceOracle} from "../src/L2/StandardRentPriceOracle.sol";
+import {StableTokenPriceOracle} from "../src/L2/StableTokenPriceOracle.sol";
+import {MockERC20, MockERC20Blacklist} from "../src/mocks/MockERC20.sol";
+
+contract TestRentPriceOracle is Test {
+    StandardRentPriceOracle rentPriceOracle;
+    StableTokenPriceOracle tokenPriceOracle;
+
+    MockERC20 tokenUSDC;
+    MockERC20 tokenDAI;
+
+    uint64 constant SEC_PER_YEAR = 31_557_600; // 365.25
+    uint8 constant PRICE_DECIMALS = 12;
+    uint256 constant PRICE_SCALE = 10 ** PRICE_DECIMALS;
+    uint256 constant RATE_5_CHAR = (5 * PRICE_SCALE) / SEC_PER_YEAR;
+    uint256 constant RATE_4_CHAR = (160 * PRICE_SCALE) / SEC_PER_YEAR;
+    uint256 constant RATE_3_CHAR = (640 * PRICE_SCALE) / SEC_PER_YEAR;
+
+    function setUp() external {
+        tokenPriceOracle = new StableTokenPriceOracle();
+
+        IERC20Metadata[] memory paymentTokens = new IERC20Metadata[](2);
+        paymentTokens[0] = tokenUSDC = new MockERC20("USDC", 6);
+        paymentTokens[1] = tokenDAI = new MockERC20("DAI", 18);
+
+        rentPriceOracle = new StandardRentPriceOracle(
+            PRICE_DECIMALS,
+            [0, 0, RATE_3_CHAR, RATE_4_CHAR, RATE_5_CHAR],
+            21 days,
+            1 days,
+            100_000_000 * PRICE_SCALE,
+            tokenPriceOracle,
+            paymentTokens
+        );
+    }
+
+    function test_supportsInterface() external view {
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(rentPriceOracle),
+                type(IRentPriceOracle).interfaceId
+            )
+        );
+    }
+
+    function test_isValid() external view {
+        assertFalse(rentPriceOracle.isValid(""));
+        assertFalse(rentPriceOracle.isValid("a"));
+        assertFalse(rentPriceOracle.isValid("ab"));
+
+        assertTrue(rentPriceOracle.isValid("abc"));
+        assertTrue(rentPriceOracle.isValid("abce"));
+        assertTrue(rentPriceOracle.isValid("abcde"));
+        assertTrue(rentPriceOracle.isValid("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    function _testRentPrice(string memory label, uint256 rate) internal {
+        uint256 base = rentPriceOracle.baseRate(label);
+        assertEq(base, rate, "rate");
+        _testRentPrice(label, rate, SEC_PER_YEAR, tokenUSDC);
+        _testRentPrice(label, rate, SEC_PER_YEAR * 2, tokenDAI);
+    }
+
+    function _testRentPrice(
+        string memory label,
+        uint256 rate,
+        uint64 dur,
+        IERC20Metadata token
+    ) internal {
+        if (rate == 0) {
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    IRentPriceOracle.NotRentable.selector,
+                    label
+                )
+            );
+        }
+        (uint256 base, ) = rentPriceOracle.rentPrice(label, 0, dur, token);
+        assertEq(
+            base,
+            tokenPriceOracle.getTokenAmount(rate * dur, PRICE_DECIMALS, token),
+            token.name()
+        );
+    }
+
+    function test_rentPrice_0() external {
+        _testRentPrice("", 0);
+    }
+    function test_rentPrice_1() external {
+        _testRentPrice("a", 0);
+    }
+    function test_rentPrice_2() external {
+        _testRentPrice("ab", 0);
+    }
+    function test_rentPrice_3() external {
+        _testRentPrice("abc", RATE_3_CHAR);
+    }
+    function test_rentPrice_4() external {
+        _testRentPrice("abcd", RATE_4_CHAR);
+    }
+    function test_rentPrice_5() external {
+        _testRentPrice("abcde", RATE_5_CHAR);
+    }
+    function test_rentPrice_long() external {
+        _testRentPrice("abcdefghijklmnopqrstuvwxyz", RATE_5_CHAR);
+    }
+
+    function test_premiumPriceAfter_start() external view {
+        assertEq(
+            rentPriceOracle.premiumPriceAfter(0),
+            rentPriceOracle.premiumPriceInitial() -
+                rentPriceOracle.premiumPriceOffset()
+        );
+    }
+
+    function test_premiumPriceAfter_end() external view {
+        uint64 dur = rentPriceOracle.premiumPeriod();
+        uint64 dt = 1;
+        assertGt(rentPriceOracle.premiumPriceAfter(dur - dt), 0, "before");
+        assertEq(rentPriceOracle.premiumPriceAfter(dur), 0, "at");
+        assertEq(rentPriceOracle.premiumPriceAfter(dur + dt), 0, "after");
+    }
+}

--- a/contracts/test/StandardRentPriceOracle.t.sol
+++ b/contracts/test/StandardRentPriceOracle.t.sol
@@ -34,9 +34,9 @@ contract TestRentPriceOracle is Test {
         rentPriceOracle = new StandardRentPriceOracle(
             PRICE_DECIMALS,
             [0, 0, RATE_3_CHAR, RATE_4_CHAR, RATE_5_CHAR],
-            21 days,
-            1 days,
-            100_000_000 * PRICE_SCALE,
+            21 days, // premiumPeriod
+            1 days, // premiumHavingPeriod
+            100_000_000 * PRICE_SCALE, // premiumPriceInitial
             tokenPriceOracle,
             paymentTokens
         );


### PR DESCRIPTION
```
ETHRegistrar ==> IRentPriceOracle
                       \/
             StandardRentPriceOracle ==> ITokenPriceOracle
                                                \/
                                      StableTokenPriceOracle
```
* added [IRentPriceOracle.sol](https://github.com/ensdomains/namechain/blob/fix/redesign-eth-registrar-split/contracts/src/L2/IRentPriceOracle.sol)
* added [StandardRentPriceOracle.sol](https://github.com/ensdomains/namechain/blob/fix/redesign-eth-registrar-split/contracts/src/L2/StandardRentPriceOracle.sol) and [tests](https://github.com/ensdomains/namechain/blob/fix/redesign-eth-registrar-split/contracts/test/StandardRentPriceOracle.t.sol)
    - moved logic from `ETHRegistrar`
    - changed `basePrice()` to `baseRate()`
    - changed `isValid()` to `baseRate() > 0` instead of `_isValidLength()`
* `IETHRegistrar.{isValid, isPaymentToken}` forward to `IRentPriceOracle`
* `IETHRegistrar.rentPrice()` takes `owner` but `IRentPriceOracle.rentPrice()` takes `expiry`
    - avoids needing an additional registry reference in `IRentPriceOracle`
* added `ETHRegistrar.setRentPriceOracle()` so pricing logic can be upgraded
* renamed `PriceUtils` to `HalvingUtils`
* removed `SafeERC20` — according to tate

---

* do we want `minRenewDuration`? — using `1 sec`
* unsure  on `StandardRentPriceOracle` name? `RentPriceOracle`, `ExponentialRentPriceOracle`, `HalvingPremiumRentPriceOracle` — is oracle even the right word?
* unsure on `RentPriceOracleChanged` event name and args — currently empty
* possibly `paymentTokens` should be iterable?