### PR TITLE
Remove contract build step from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,6 @@ RUN git config --global init.defaultBranch main && \
     cd contracts && \
     forge i
 
-# Build Contracts
-RUN bun run compile:hardhat
-
 # Expose ports for L1 and L2
 EXPOSE 8545
 EXPOSE 8546


### PR DESCRIPTION
This PR removes the hardhat compilation during build. This assumes the correct action is to only compile when running the devnet, and not during build.